### PR TITLE
Add interactive teams map with Leaflet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "our-big-league",
       "version": "1.0.0",
       "dependencies": {
+        "@vue-leaflet/vue-leaflet": "^0.10.1",
+        "leaflet": "^1.9.4",
         "vue": "^3.4.0",
         "vue-router": "^4.2.0"
       },
@@ -916,6 +918,24 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vue-leaflet/vue-leaflet": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@vue-leaflet/vue-leaflet/-/vue-leaflet-0.10.1.tgz",
+      "integrity": "sha512-RNEDk8TbnwrJl8ujdbKgZRFygLCxd0aBcWLQ05q/pGv4+d0jamE3KXQgQBqGAteE1mbQsk3xoNcqqUgaIGfWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.2.25"
+      },
+      "peerDependencies": {
+        "@types/leaflet": "^1.5.7",
+        "leaflet": "^1.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/leaflet": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.27",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.27.tgz",
@@ -1534,6 +1554,13 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@vue-leaflet/vue-leaflet": "^0.10.1",
+    "leaflet": "^1.9.4",
     "vue": "^3.4.0",
     "vue-router": "^4.2.0"
   },

--- a/public/data/teams.json
+++ b/public/data/teams.json
@@ -5,98 +5,154 @@
       "name": "AMW",
       "appearances": 3,
       "championships": 2,
-      "championshipYears": [2010, 2014]
+      "championshipYears": [2010, 2014],
+      "location": "Atlanta, GA",
+      "lat": 33.749,
+      "lng": -84.388,
+      "logo": "amw.jpg"
     },
     {
       "id": 2,
       "name": "Blank",
       "appearances": 3,
       "championships": 2,
-      "championshipYears": [2007, 2021]
+      "championshipYears": [2007, 2021],
+      "location": "Bowie, MD",
+      "lat": 38.963,
+      "lng": -76.750,
+      "logo": "blank.jpg"
     },
     {
       "id": 3,
       "name": "Birrrrdy",
       "appearances": 7,
       "championships": 4,
-      "championshipYears": [1999, 2005, 2006, 2016]
+      "championshipYears": [1999, 2005, 2006, 2016],
+      "location": "San Diego, CA",
+      "lat": 32.726,
+      "lng": -117.161,
+      "logo": "birrrdy.jpg"
     },
     {
       "id": 4,
       "name": "Burghman",
       "appearances": 1,
       "championships": 0,
-      "championshipYears": []
+      "championshipYears": [],
+      "location": "San Diego, CA",
+      "lat": 32.706,
+      "lng": -117.161,
+      "logo": "burghman.jpg"
     },
     {
       "id": 5,
       "name": "Gunslingers",
       "appearances": 2,
       "championships": 0,
-      "championshipYears": []
+      "championshipYears": [],
+      "location": "New Orleans, LA",
+      "lat": 29.951,
+      "lng": -90.072,
+      "logo": "gunslingers.jpg"
     },
     {
       "id": 6,
       "name": "Hampton Ballers",
       "appearances": 7,
       "championships": 5,
-      "championshipYears": [2001, 2003, 2008, 2019, 2020]
+      "championshipYears": [2001, 2003, 2008, 2019, 2020],
+      "location": "Killeen, TX",
+      "lat": 31.117,
+      "lng": -97.727,
+      "logo": "hb.jpg"
     },
     {
       "id": 7,
       "name": "Jamaica's Finest",
       "appearances": 3,
       "championships": 0,
-      "championshipYears": []
+      "championshipYears": [],
+      "location": "Bowie, MD",
+      "lat": 38.923,
+      "lng": -76.750,
+      "logo": "jf.jpg"
     },
     {
       "id": 8,
       "name": "Junkyard Dawgs",
       "appearances": 1,
       "championships": 1,
-      "championshipYears": [2023]
+      "championshipYears": [2023],
+      "location": "Dallas, TX",
+      "lat": 32.777,
+      "lng": -96.797,
+      "logo": "jyd.jpg"
     },
     {
       "id": 9,
       "name": "Makaveli",
       "appearances": 2,
       "championships": 1,
-      "championshipYears": [2000]
+      "championshipYears": [2000],
+      "location": "Indianapolis, IN",
+      "lat": 39.768,
+      "lng": -86.158,
+      "logo": "mak.jpg"
     },
     {
       "id": 10,
       "name": "Menace",
       "appearances": 5,
       "championships": 2.5,
-      "championshipYears": [2011, 2015, 2022]
+      "championshipYears": [2011, 2015, 2022],
+      "location": "Bowie, MD",
+      "lat": 38.963,
+      "lng": -76.710,
+      "logo": "menace.jpg"
     },
     {
       "id": 11,
       "name": "Outta Control",
       "appearances": 2,
       "championships": 1,
-      "championshipYears": [2012]
+      "championshipYears": [2012],
+      "location": "Philadelphia, PA",
+      "lat": 39.952,
+      "lng": -75.164,
+      "logo": "oc.jpg"
     },
     {
       "id": 12,
       "name": "Showtime",
       "appearances": 4,
       "championships": 1.5,
-      "championshipYears": [2017, 2022]
+      "championshipYears": [2017, 2022],
+      "location": "Springfield, VA",
+      "lat": 38.789,
+      "lng": -77.187,
+      "logo": "showtime.jpg"
     },
     {
       "id": 13,
       "name": "Skindeep Ballaz",
       "appearances": 6,
       "championships": 4,
-      "championshipYears": [2002, 2004, 2009, 2018]
+      "championshipYears": [2002, 2004, 2009, 2018],
+      "location": "Lorton, VA",
+      "lat": 38.704,
+      "lng": -77.228,
+      "logo": "skindeep.png"
     },
     {
       "id": 14,
       "name": "Stout",
       "appearances": 3,
       "championships": 2,
-      "championshipYears": [1998, 2013]
+      "championshipYears": [1998, 2013],
+      "location": "Bowie, MD",
+      "lat": 38.923,
+      "lng": -76.710,
+      "logo": "stout.jpg"
     }
   ]
 }

--- a/src/pages/TeamsPage.vue
+++ b/src/pages/TeamsPage.vue
@@ -1,9 +1,140 @@
 <script setup>
+import { ref, onMounted, computed } from 'vue'
+import 'leaflet/dist/leaflet.css'
+import { LMap, LTileLayer, LMarker, LPopup, LIcon } from '@vue-leaflet/vue-leaflet'
+
+const teams = ref([])
+const loading = ref(true)
+const error = ref(null)
+const mapRef = ref(null)
+
+// Map configuration - centered on continental US
+const defaultCenter = [39.5, -98.35]
+const defaultZoom = 4
+const mapCenter = ref([...defaultCenter])
+const mapZoom = ref(defaultZoom)
+
+// Import all logo images dynamically
+const logoModules = import.meta.glob('@/assets/*.{jpg,png}', { eager: true })
+
+const getLogoUrl = (logoFile) => {
+  for (const [key, module] of Object.entries(logoModules)) {
+    if (key.endsWith(logoFile)) {
+      return module.default
+    }
+  }
+  return null
+}
+
+const teamsWithLogos = computed(() => {
+  return teams.value.map(team => ({
+    ...team,
+    logoUrl: getLogoUrl(team.logo)
+  }))
+})
+
+const resetMap = () => {
+  if (mapRef.value?.leafletObject) {
+    mapRef.value.leafletObject.setView(defaultCenter, defaultZoom)
+  }
+}
+
+onMounted(async () => {
+  try {
+    const response = await fetch('/data/teams.json')
+    if (!response.ok) throw new Error('Failed to load team data')
+    const data = await response.json()
+    teams.value = data.teams
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+})
 </script>
 
 <template>
-  <div class="max-w-4xl mx-auto px-4 py-8">
-    <h1 class="text-2xl font-bold mb-4">Teams Map</h1>
-    <p class="text-gray-600">Interactive map coming soon...</p>
+  <div class="py-8 px-4">
+    <div class="max-w-6xl mx-auto">
+      <h1 class="text-2xl font-bold mb-6 text-center">Teams Map</h1>
+
+      <div v-if="loading" class="text-center py-8">Loading map...</div>
+      <div v-else-if="error" class="text-red-500 py-8 text-center">{{ error }}</div>
+
+      <div v-else class="relative rounded-lg overflow-hidden shadow-lg border border-gray-200">
+        <!-- Home Button -->
+        <button
+          @click="resetMap"
+          class="absolute top-3 right-3 z-[1000] bg-white hover:bg-gray-100 text-gray-700 px-3 py-2 rounded-lg shadow-md border border-gray-300 flex items-center gap-2 transition-colors"
+          title="Reset to default view"
+        >
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+          </svg>
+          <span class="text-sm font-medium">Home</span>
+        </button>
+
+        <l-map
+          ref="mapRef"
+          :zoom="mapZoom"
+          :center="mapCenter"
+          :use-global-leaflet="false"
+          style="height: 600px; width: 100%;"
+        >
+          <!-- CartoDB Positron - clean, modern, minimal -->
+          <l-tile-layer
+            url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+            layer-type="base"
+            name="CartoDB Positron"
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+          />
+
+          <l-marker
+            v-for="team in teamsWithLogos"
+            :key="team.id"
+            :lat-lng="[team.lat, team.lng]"
+          >
+            <l-icon
+              :icon-url="team.logoUrl"
+              :icon-size="[40, 40]"
+              :icon-anchor="[20, 20]"
+              :popup-anchor="[0, -20]"
+              class-name="team-marker"
+            />
+            <l-popup>
+              <div class="text-center min-w-[150px]">
+                <img
+                  :src="team.logoUrl"
+                  :alt="team.name"
+                  class="w-12 h-12 mx-auto mb-2 rounded"
+                />
+                <h3 class="font-bold text-lg">{{ team.name }}</h3>
+                <p class="text-sm text-gray-600">{{ team.location }}</p>
+                <div class="mt-2 text-sm">
+                  <p><span class="font-medium">Championships:</span> {{ team.championships }}</p>
+                  <p><span class="font-medium">Appearances:</span> {{ team.appearances }}</p>
+                  <p v-if="team.championshipYears.length" class="text-xs text-gray-500 mt-1">
+                    {{ team.championshipYears.join(', ') }}
+                  </p>
+                </div>
+              </div>
+            </l-popup>
+          </l-marker>
+        </l-map>
+      </div>
+    </div>
   </div>
 </template>
+
+<style>
+.team-marker {
+  border-radius: 50%;
+  border: 2px solid #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+}
+
+.team-marker img {
+  border-radius: 50%;
+  object-fit: cover;
+}
+</style>


### PR DESCRIPTION
## Summary
- Interactive Leaflet map showing team locations across the US
- Team logos as custom markers
- CartoDB Positron tile layer for clean, modern look
- Home button to reset view to continental US
- Popup on click shows team name, location, championships, and appearances
- Offset markers for cities with multiple teams (Bowie has 4, San Diego has 2)

## Test plan
- [ ] Navigate to /teams
- [ ] Verify map is centered on continental US
- [ ] Verify all 14 team logos appear at correct locations
- [ ] Click a marker to see team info popup
- [ ] Zoom/pan around, then click Home to reset view