### PR TITLE
Switch to traditional top navigation and fix map issues

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,23 +1,46 @@
 <script setup>
+import { RouterLink } from 'vue-router'
 import oblIcon from '../assets/obl-icon.png'
 
 defineEmits(['toggle-nav'])
+
+const navItems = [
+  { name: 'Teams', path: '/teams' },
+  { name: 'Drafts', path: '/drafts' },
+  { name: 'Champions', path: '/champions' },
+  { name: 'About', path: '/about' },
+]
 </script>
 
 <template>
-  <header class="fixed top-0 left-0 right-0 z-50 bg-black text-white h-16 flex items-center px-4 shadow-lg">
+  <header class="fixed top-0 left-0 right-0 z-50 bg-black text-white h-16 flex items-center justify-between px-4 shadow-lg">
+    <!-- Logo - links to home -->
+    <router-link to="/" class="flex items-center hover:opacity-80 transition-opacity">
+      <img :src="oblIcon" alt="OBL Logo" class="w-10 h-10 mr-3" />
+      <span class="text-xl font-medium">Our Big League</span>
+    </router-link>
+
+    <!-- Desktop Navigation -->
+    <nav class="hidden md:flex items-center gap-6">
+      <router-link
+        v-for="item in navItems"
+        :key="item.path"
+        :to="item.path"
+        class="text-white hover:text-gray-300 transition-colors font-medium"
+      >
+        {{ item.name }}
+      </router-link>
+    </nav>
+
+    <!-- Mobile Hamburger Button -->
     <button
       @click="$emit('toggle-nav')"
-      class="p-2 hover:bg-gray-800 rounded-lg mr-4"
+      class="md:hidden p-2 hover:bg-gray-800 rounded-lg"
       aria-label="Toggle navigation"
     >
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
       </svg>
     </button>
-    <div class="flex items-center">
-      <img :src="oblIcon" alt="OBL Logo" class="w-10 h-10 mr-3" />
-      <span class="text-xl font-medium">Our Big League</span>
-    </div>
   </header>
 </template>

--- a/src/components/AppNav.vue
+++ b/src/components/AppNav.vue
@@ -10,10 +10,9 @@ const emit = defineEmits(['close'])
 const router = useRouter()
 
 const navItems = [
-  { name: 'Home', path: '/' },
-  { name: 'Champions', path: '/champions' },
-  { name: 'Drafts', path: '/drafts' },
   { name: 'Teams', path: '/teams' },
+  { name: 'Drafts', path: '/drafts' },
+  { name: 'Champions', path: '/champions' },
   { name: 'About', path: '/about' },
 ]
 
@@ -31,19 +30,21 @@ watch(() => router.currentRoute.value, () => {
   <!-- Backdrop -->
   <div
     v-if="isOpen"
-    class="fixed inset-0 bg-black/50 z-40"
+    class="fixed inset-0 bg-black/50 z-[1100]"
     @click="$emit('close')"
   />
 
   <!-- Drawer -->
   <aside
     :class="[
-      'fixed top-0 left-0 h-full w-64 bg-black text-white z-50 transform transition-transform duration-300 ease-in-out',
-      isOpen ? 'translate-x-0' : '-translate-x-full'
+      'fixed top-0 right-0 h-full w-64 bg-black text-white z-[1200] transform transition-transform duration-300 ease-in-out',
+      isOpen ? 'translate-x-0' : 'translate-x-full'
     ]"
   >
     <div class="p-4 border-b border-gray-700">
-      <h2 class="text-lg font-medium">Our Big League</h2>
+      <button @click="navigateTo('/')" class="text-lg font-medium hover:text-gray-300 transition-colors">
+        Our Big League
+      </button>
     </div>
     <nav class="py-4">
       <button

--- a/src/pages/TeamsPage.vue
+++ b/src/pages/TeamsPage.vue
@@ -10,9 +10,16 @@ const mapRef = ref(null)
 
 // Map configuration - centered on continental US
 const defaultCenter = [39.5, -98.35]
-const defaultZoom = 4
+const desktopZoom = 4
+const mobileZoom = 3
+const mobileBreakpoint = 640  // Phones only - tablets use desktop zoom
+
+const getDefaultZoom = () => {
+  return window.innerWidth < mobileBreakpoint ? mobileZoom : desktopZoom
+}
+
 const mapCenter = ref([...defaultCenter])
-const mapZoom = ref(defaultZoom)
+const mapZoom = ref(getDefaultZoom())
 
 // Import all logo images dynamically
 const logoModules = import.meta.glob('@/assets/*.{jpg,png}', { eager: true })
@@ -35,7 +42,7 @@ const teamsWithLogos = computed(() => {
 
 const resetMap = () => {
   if (mapRef.value?.leafletObject) {
-    mapRef.value.leafletObject.setView(defaultCenter, defaultZoom)
+    mapRef.value.leafletObject.setView(defaultCenter, getDefaultZoom())
   }
 }
 


### PR DESCRIPTION
## Summary

**Navigation:**
- Add inline nav links in header for desktop (Teams, Drafts, Champions, About)
- Keep hamburger menu for mobile, now slides from right side
- Make OBL logo clickable to return to homepage
- Fix z-index so mobile nav appears above Leaflet map

**Map:**
- Add responsive zoom levels (4 for desktop/tablet, 3 for phones)
- Breakpoint at 640px ensures tablets use desktop zoom

## Test plan
- [ ] Desktop: Nav links visible in header, no hamburger
- [ ] Desktop: Click logo → homepage
- [ ] Mobile: Hamburger visible, nav slides from right
- [ ] Mobile: Nav appears above map on Teams page
- [ ] Tablet (iPad): Uses desktop zoom level on map
- [ ] Phone: Uses mobile zoom level on map