### PR TITLE
Add host info, sortable history, and bar chart race visualization

### DIFF
--- a/src/components/champions/ChampionshipHistory.vue
+++ b/src/components/champions/ChampionshipHistory.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
 import { RouterLink } from 'vue-router'
 
 const props = defineProps({
@@ -19,9 +19,63 @@ const defunctTeams = new Set([
 
 const isDefunct = (name) => defunctTeams.has(name)
 
-// Sort seasons by year descending (most recent first)
+// Sorting state
+const sortColumn = ref('year')
+const sortDirection = ref('desc')
+
+// Toggle sort column
+const toggleSort = (column) => {
+  if (sortColumn.value === column) {
+    // Toggle direction if same column
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    // New column, default to ascending
+    sortColumn.value = column
+    sortDirection.value = 'asc'
+  }
+}
+
+// Sort seasons based on current sort state
 const sortedSeasons = computed(() => {
-  return [...props.seasons].sort((a, b) => b.year - a.year)
+  const sorted = [...props.seasons].sort((a, b) => {
+    let aVal, bVal
+
+    switch (sortColumn.value) {
+      case 'seasonNumber':
+        aVal = a.seasonNumber
+        bVal = b.seasonNumber
+        break
+      case 'year':
+        aVal = a.year
+        bVal = b.year
+        break
+      case 'draftLocation':
+        aVal = a.draftLocation.toLowerCase()
+        bVal = b.draftLocation.toLowerCase()
+        return sortDirection.value === 'asc'
+          ? aVal.localeCompare(bVal)
+          : bVal.localeCompare(aVal)
+      case 'runnerUp':
+        aVal = a.runnerUp.toLowerCase()
+        bVal = b.runnerUp.toLowerCase()
+        return sortDirection.value === 'asc'
+          ? aVal.localeCompare(bVal)
+          : bVal.localeCompare(aVal)
+      case 'champion':
+        aVal = a.championDisplay.toLowerCase()
+        bVal = b.championDisplay.toLowerCase()
+        return sortDirection.value === 'asc'
+          ? aVal.localeCompare(bVal)
+          : bVal.localeCompare(aVal)
+      default:
+        aVal = a.year
+        bVal = b.year
+    }
+
+    return sortDirection.value === 'asc' ? aVal - bVal : bVal - aVal
+  })
+
+  return sorted
 })
 </script>
 
@@ -30,11 +84,61 @@ const sortedSeasons = computed(() => {
     <table class="min-w-full bg-white rounded-lg overflow-hidden shadow-lg">
       <thead>
         <tr class="bg-obl-header text-white">
-          <th class="px-4 py-3 text-center text-sm font-semibold w-16">Year</th>
-          <th class="px-4 py-3 text-center text-sm font-semibold w-20">Season</th>
-          <th class="px-4 py-3 text-center text-sm font-semibold">Draft Location</th>
-          <th class="px-4 py-3 text-center text-sm font-semibold bg-gray-500">Runner Up</th>
-          <th class="px-4 py-3 text-center text-sm font-semibold bg-amber-500">Champion</th>
+          <th
+            @click="toggleSort('seasonNumber')"
+            class="px-4 py-3 text-center text-sm font-semibold w-16 cursor-pointer hover:bg-blue-700 transition-colors select-none"
+          >
+            <div class="flex items-center justify-center gap-1">
+              <span>Year</span>
+              <span v-if="sortColumn === 'seasonNumber'" class="text-xs">
+                {{ sortDirection === 'asc' ? '▲' : '▼' }}
+              </span>
+            </div>
+          </th>
+          <th
+            @click="toggleSort('year')"
+            class="px-4 py-3 text-center text-sm font-semibold w-20 cursor-pointer hover:bg-blue-700 transition-colors select-none"
+          >
+            <div class="flex items-center justify-center gap-1">
+              <span>Season</span>
+              <span v-if="sortColumn === 'year'" class="text-xs">
+                {{ sortDirection === 'asc' ? '▲' : '▼' }}
+              </span>
+            </div>
+          </th>
+          <th
+            @click="toggleSort('draftLocation')"
+            class="px-4 py-3 text-center text-sm font-semibold cursor-pointer hover:bg-blue-700 transition-colors select-none"
+          >
+            <div class="flex items-center justify-center gap-1">
+              <span>Draft Location</span>
+              <span v-if="sortColumn === 'draftLocation'" class="text-xs">
+                {{ sortDirection === 'asc' ? '▲' : '▼' }}
+              </span>
+            </div>
+          </th>
+          <th
+            @click="toggleSort('runnerUp')"
+            class="px-4 py-3 text-center text-sm font-semibold bg-gray-500 cursor-pointer hover:bg-gray-600 transition-colors select-none"
+          >
+            <div class="flex items-center justify-center gap-1">
+              <span>Runner Up</span>
+              <span v-if="sortColumn === 'runnerUp'" class="text-xs">
+                {{ sortDirection === 'asc' ? '▲' : '▼' }}
+              </span>
+            </div>
+          </th>
+          <th
+            @click="toggleSort('champion')"
+            class="px-4 py-3 text-center text-sm font-semibold bg-amber-500 cursor-pointer hover:bg-amber-600 transition-colors select-none"
+          >
+            <div class="flex items-center justify-center gap-1">
+              <span>Champion</span>
+              <span v-if="sortColumn === 'champion'" class="text-xs">
+                {{ sortDirection === 'asc' ? '▲' : '▼' }}
+              </span>
+            </div>
+          </th>
         </tr>
       </thead>
       <tbody>
@@ -63,7 +167,7 @@ const sortedSeasons = computed(() => {
             </span>
           </td>
           <td class="px-4 py-3 text-center font-semibold bg-amber-50 text-amber-600">
-            {{ season.champion }}
+            {{ season.championDisplay }}
           </td>
         </tr>
       </tbody>

--- a/src/components/champions/ChampionshipSummary.vue
+++ b/src/components/champions/ChampionshipSummary.vue
@@ -8,58 +8,164 @@ const props = defineProps({
   }
 })
 
-// Tiers are already sorted 0 to highest from composable
-const sortedTiers = computed(() => props.tiers)
+// Import all logo images dynamically
+const logoModules = import.meta.glob('@/assets/*.{jpg,png}', { eager: true })
 
-// Get color based on championship count
-const getTierColor = (count) => {
-  if (count >= 5) return 'bg-obl-champion text-white'
-  if (count >= 4) return 'bg-yellow-500 text-white'
-  if (count >= 3) return 'bg-yellow-400 text-gray-800'
-  if (count >= 2) return 'bg-obl-header text-white'
-  if (count >= 1) return 'bg-blue-400 text-white'
-  return 'bg-gray-400 text-white'
+const getLogoUrl = (teamName) => {
+  // Map team names to logo filenames
+  const logoMap = {
+    'AMW': 'amw.jpg',
+    'Blank': 'blank.jpg',
+    'Birrrdy': 'birrrdy.jpg',
+    'Burghman': 'burghman.jpg',
+    'Gunslingers': 'gunslingers.jpg',
+    'Hampton Ballers': 'hb.jpg',
+    "Jamaica's Finest": 'jf.jpg',
+    'Junkyard Dawgs': 'jyd.jpg',
+    'Makaveli': 'mak.jpg',
+    'Menace': 'menace.jpg',
+    'Outta Control': 'oc.jpg',
+    'Showtime': 'showtime.jpg',
+    'Skindeep Ballaz': 'skindeep.png',
+    'Stout': 'stout.jpg'
+  }
+
+  const logoFile = logoMap[teamName]
+  if (!logoFile) return null
+
+  for (const [key, module] of Object.entries(logoModules)) {
+    if (key.endsWith(logoFile)) {
+      return module.default
+    }
+  }
+  return null
 }
+
+// Flatten tiers into teams array and sort by appearances
+const rankedTeams = computed(() => {
+  const teams = []
+
+  props.tiers.forEach(tier => {
+    tier.teams.forEach(team => {
+      teams.push({
+        name: team.name,
+        championships: tier.count,
+        appearances: team.appearances,
+        logoUrl: getLogoUrl(team.name)
+      })
+    })
+  })
+
+  // Sort by appearances descending (most at top), then by championships
+  return teams.sort((a, b) => {
+    if (b.appearances !== a.appearances) {
+      return b.appearances - a.appearances
+    }
+    return b.championships - a.championships
+  })
+})
+
+// Max appearances for scaling
+const maxAppearances = computed(() => {
+  return Math.max(...rankedTeams.value.map(t => t.appearances))
+})
 </script>
 
 <template>
   <div class="mt-8">
     <h2 class="text-xl font-bold mb-4 text-gray-800">Championships (Appearances)</h2>
 
-    <div class="overflow-x-auto">
-      <table class="min-w-full bg-white rounded-lg overflow-hidden shadow-lg">
-        <thead>
-          <tr>
-            <th
-              v-for="tier in sortedTiers"
-              :key="tier.count"
-              :class="[getTierColor(tier.count), 'px-4 py-3 text-center text-sm font-bold']"
+    <div class="bg-white rounded-lg shadow-lg p-6">
+      <!-- Chart container -->
+      <div class="space-y-2">
+        <!-- Header row with scale -->
+        <div class="flex items-end">
+          <div class="w-36 flex-shrink-0"></div>
+          <div class="flex-1 pr-16">
+            <div
+              class="grid h-6"
+              :style="{ gridTemplateColumns: `repeat(${maxAppearances}, 1fr)` }"
             >
-              {{ tier.count }}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td
-              v-for="tier in sortedTiers"
-              :key="tier.count"
-              class="px-2 py-3 align-top border-r border-gray-200 last:border-r-0"
-            >
-              <div class="space-y-1">
-                <div
-                  v-for="team in tier.teams"
-                  :key="team.name"
-                  class="text-xs text-center"
-                >
-                  <span class="font-medium text-gray-700">{{ team.name }}</span>
-                  <span class="text-gray-400 ml-1">({{ team.appearances }})</span>
-                </div>
+              <div
+                v-for="n in maxAppearances"
+                :key="'header-' + n"
+                class="text-xs text-gray-400 text-center"
+              >
+                {{ n }}
               </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+            </div>
+          </div>
+        </div>
+
+        <!-- Team rows -->
+        <div
+          v-for="team in rankedTeams"
+          :key="team.name"
+          class="flex items-center"
+        >
+          <!-- Team name -->
+          <div class="w-36 flex-shrink-0 text-right text-sm font-medium text-gray-700 pr-4">
+            {{ team.name }}
+          </div>
+
+          <!-- Bar area with fixed grid for alignment -->
+          <div class="flex-1 relative pr-16">
+            <div
+              class="grid h-8"
+              :style="{ gridTemplateColumns: `repeat(${maxAppearances}, 1fr)` }"
+            >
+              <div
+                v-for="n in maxAppearances"
+                :key="team.name + '-cell-' + n"
+                class="h-full"
+              >
+                <div
+                  v-if="n <= team.appearances"
+                  class="w-full h-full border-r-2"
+                  :class="n <= Math.ceil(team.championships)
+                    ? 'bg-amber-500 border-amber-600'
+                    : 'bg-gray-300 border-gray-400'"
+                ></div>
+              </div>
+            </div>
+
+            <!-- Logo and count positioned after the bar -->
+            <div
+              class="absolute top-0 h-8 flex items-center pl-1"
+              :style="{ left: `calc(${(team.appearances / maxAppearances) * 100}% - 64px * ${team.appearances / maxAppearances})` }"
+            >
+              <img
+                v-if="team.logoUrl"
+                :src="team.logoUrl"
+                :alt="team.name"
+                class="w-8 h-8 rounded-full border-2 border-gray-200"
+              />
+              <span class="ml-1 text-sm font-semibold text-gray-700">
+                {{ team.appearances }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Legend -->
+      <div class="mt-6 flex items-center justify-center gap-6 text-sm text-gray-600">
+        <div class="flex items-center gap-2">
+          <div class="w-6 h-4 bg-amber-500 rounded"></div>
+          <span>Championships</span>
+        </div>
+        <div class="flex items-center gap-2">
+          <div class="w-6 h-4 bg-gray-300 rounded"></div>
+          <span>Runner-Up Appearances</span>
+        </div>
+      </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.chart-grid {
+  display: grid;
+  gap: 0;
+}
+</style>

--- a/src/composables/useChampionshipData.js
+++ b/src/composables/useChampionshipData.js
@@ -46,7 +46,9 @@ export function useChampionshipData() {
         seasonNumber: season.season_number,
         year: season.year,
         draftLocation: season.draft_location?.city || 'Unknown',
-        champion: season.champion_display_name || season.champion?.name || 'Unknown',
+        champion: season.champion,  // Keep full team object with owner info
+        championDisplay: season.champion_display_name || season.champion?.name || 'Unknown',
+        coChampion: season.co_champion,  // Keep full co-champion object
         runnerUp: season.runner_up_display_name || season.runner_up?.name || '------',
         note: season.notes,
         isCoChampionship: season.is_co_championship

--- a/src/pages/DraftDetailPage.vue
+++ b/src/pages/DraftDetailPage.vue
@@ -25,6 +25,41 @@ const nextYear = computed(() => {
   return idx < seasons.value.length - 1 ? seasons.value[idx + 1].year : null
 })
 
+const host = computed(() => {
+  if (!seasons.value || !nextYear.value) return null
+  const prevSeason = seasons.value.find(s => s.year === nextYear.value)
+  if (!prevSeason) return null
+
+  const championTeam = prevSeason.champion
+  if (!championTeam) return null
+
+  // Check if co-championship year
+  if (prevSeason.isCoChampionship && prevSeason.coChampion) {
+    // Return both champions for co-championship
+    return {
+      isCoChampionship: true,
+      champion1: {
+        firstName: championTeam.owner_first_name,
+        lastName: championTeam.owner_last_name,
+        teamName: championTeam.name
+      },
+      champion2: {
+        firstName: prevSeason.coChampion.owner_first_name,
+        lastName: prevSeason.coChampion.owner_last_name,
+        teamName: prevSeason.coChampion.name
+      }
+    }
+  }
+
+  // Regular single champion
+  return {
+    isCoChampionship: false,
+    firstName: championTeam.owner_first_name,
+    lastName: championTeam.owner_last_name,
+    teamName: championTeam.name
+  }
+})
+
 // Championship data is fetched automatically by useChampionshipData composable
 </script>
 
@@ -65,6 +100,12 @@ const nextYear = computed(() => {
             <div class="text-center">
               <h1 class="text-3xl font-bold text-obl-header">{{ year }} Draft</h1>
               <p class="text-gray-500">Season {{ season.seasonNumber }}</p>
+              <p v-if="host && !host.isCoChampionship" class="text-sm text-gray-600 mt-1">
+                Hosted by: {{ host.firstName }} {{ host.lastName }} ({{ host.teamName }})
+              </p>
+              <p v-if="host && host.isCoChampionship" class="text-sm text-gray-600 mt-1">
+                Hosted by: {{ host.champion1.firstName }} {{ host.champion1.lastName }} ({{ host.champion1.teamName }}) & {{ host.champion2.firstName }} {{ host.champion2.lastName }} ({{ host.champion2.teamName }})
+              </p>
             </div>
 
             <RouterLink
@@ -96,7 +137,7 @@ const nextYear = computed(() => {
             <!-- Champion -->
             <div class="bg-amber-50 rounded-lg p-4 text-center border-2 border-amber-500">
               <div class="text-sm text-gray-500 mb-1">Champion</div>
-              <div class="text-lg font-bold text-amber-600">{{ season.champion }}</div>
+              <div class="text-lg font-bold text-amber-600">{{ season.championDisplay }}</div>
             </div>
           </div>
 

--- a/src/services/seasonService.js
+++ b/src/services/seasonService.js
@@ -19,13 +19,17 @@ export async function getSeasons() {
         id,
         name,
         logo,
-        is_active
+        is_active,
+        owner_first_name,
+        owner_last_name
       ),
       co_champion:teams!seasons_co_champion_id_fkey (
         id,
         name,
         logo,
-        is_active
+        is_active,
+        owner_first_name,
+        owner_last_name
       ),
       runner_up:teams!seasons_runner_up_id_fkey (
         id,
@@ -59,13 +63,17 @@ export async function getSeasonByYear(year) {
         id,
         name,
         logo,
-        is_active
+        is_active,
+        owner_first_name,
+        owner_last_name
       ),
       co_champion:teams!seasons_co_champion_id_fkey (
         id,
         name,
         logo,
-        is_active
+        is_active,
+        owner_first_name,
+        owner_last_name
       ),
       runner_up:teams!seasons_runner_up_id_fkey (
         id,


### PR DESCRIPTION
## Summary
- Add "Hosted by" information to draft detail pages showing the previous year's champion owner
- Make ChampionshipHistory table columns sortable with click-to-sort and visual indicators
- Redesign ChampionshipSummary as a bar chart race visualization

## Changes

**Draft Detail Page (`DraftDetailPage.vue`):**
- Shows "Hosted by: [FirstName] [LastName] ([TeamName])" under the season title
- Handles co-championships by displaying both owners
- First season (1998) has no host displayed

**Championship History (`ChampionshipHistory.vue`):**
- All 5 columns are now sortable (Year, Season, Draft Location, Runner Up, Champion)
- Click header to sort, click again to toggle ascending/descending
- Visual indicators (▲/▼) show current sort column and direction

**Championship Summary (`ChampionshipSummary.vue`):**
- Redesigned as horizontal bar chart race visualization
- Gold bars = championships, Gray bars = runner-up appearances
- Teams ranked by total appearances
- Team logo positioned after each bar
- CSS Grid ensures perfect tick alignment across all rows

**Data Layer:**
- Updated seasonService queries to include owner_first_name and owner_last_name
- Updated composable to preserve full champion objects (for owner access)
- Added championDisplay field for text display

## Test plan
- [x] `/drafts/2024` shows host from 2023 champion
- [x] `/drafts/2023` shows both co-champion hosts from 2022
- [x] `/drafts/1998` shows no host (first season)
- [x] `/champions` history table columns are sortable
- [x] `/champions` bar chart shows aligned ticks like bricks

🤖 Generated with [Claude Code](https://claude.ai/code)