### PR TITLE
add team lineage tracking and half-championship visualization

### DIFF
--- a/src/components/champions/ChampionshipSummary.vue
+++ b/src/components/champions/ChampionshipSummary.vue
@@ -69,6 +69,19 @@ const rankedTeams = computed(() => {
 const maxAppearances = computed(() => {
   return Math.max(...rankedTeams.value.map(t => t.appearances))
 })
+
+// Determine brick type for each cell
+const getBrickType = (cellIndex, championships) => {
+  const fullChamps = Math.floor(championships)
+  const hasHalf = championships % 1 !== 0
+
+  if (cellIndex <= fullChamps) {
+    return 'full'
+  } else if (cellIndex === fullChamps + 1 && hasHalf) {
+    return 'half'
+  }
+  return 'gray'
+}
 </script>
 
 <template>
@@ -122,9 +135,14 @@ const maxAppearances = computed(() => {
                 <div
                   v-if="n <= team.appearances"
                   class="w-full h-full border-r-2"
-                  :class="n <= Math.ceil(team.championships)
-                    ? 'bg-amber-500 border-amber-600'
-                    : 'bg-gray-300 border-gray-400'"
+                  :class="{
+                    'bg-amber-500 border-amber-600': getBrickType(n, team.championships) === 'full',
+                    'border-amber-600': getBrickType(n, team.championships) === 'half',
+                    'bg-gray-300 border-gray-400': getBrickType(n, team.championships) === 'gray'
+                  }"
+                  :style="getBrickType(n, team.championships) === 'half'
+                    ? { background: 'linear-gradient(to right, #f59e0b 50%, #d1d5db 50%)' }
+                    : {}"
                 ></div>
               </div>
             </div>

--- a/src/services/teamService.js
+++ b/src/services/teamService.js
@@ -37,6 +37,7 @@ export async function getTeamById(id) {
 
 /**
  * Fetch all teams with their championship stats calculated
+ * Includes inherited stats from predecessor teams (e.g., 2 Deep → Jamaica's Finest + Showtime)
  * @returns {Promise<{data: Array, error: Error|null}>}
  */
 export async function getTeamsWithStats() {
@@ -56,33 +57,54 @@ export async function getTeamsWithStats() {
 
   if (seasonsError) return { data: null, error: seasonsError }
 
+  // Get team lineage to find predecessors
+  const { data: lineage, error: lineageError } = await supabase
+    .from('team_lineage')
+    .select('predecessor_id, successor_id')
+
+  if (lineageError) return { data: null, error: lineageError }
+
+  // Build predecessor map: successor_id -> [predecessor_ids]
+  const predecessorMap = {}
+  lineage?.forEach(l => {
+    if (!predecessorMap[l.successor_id]) {
+      predecessorMap[l.successor_id] = []
+    }
+    predecessorMap[l.successor_id].push(l.predecessor_id)
+  })
+
   // Calculate stats for each team
   const teamsWithStats = teams.map(team => {
     let championships = 0
     let appearances = 0
     const championshipYears = []
 
-    seasons.forEach(season => {
-      const isChampion = season.champion_id === team.id
-      const isCoChampion = season.co_champion_id === team.id
-      const isRunnerUp = season.runner_up_id === team.id
+    // Get all team IDs to count (team + predecessors)
+    const teamIds = [team.id, ...(predecessorMap[team.id] || [])]
 
-      if (isChampion) {
-        // Check if it's a co-championship
-        if (season.co_champion_id) {
+    seasons.forEach(season => {
+      teamIds.forEach(teamId => {
+        const isChampion = season.champion_id === teamId
+        const isCoChampion = season.co_champion_id === teamId
+        const isRunnerUp = season.runner_up_id === teamId
+
+        if (isChampion) {
+          // Check if it's a co-championship
+          if (season.co_champion_id) {
+            championships += 0.5
+          } else {
+            championships += 1
+          }
+          championshipYears.push(season.year)
+          appearances += 1
+        } else if (isCoChampion) {
           championships += 0.5
-        } else {
-          championships += 1
+          championshipYears.push(season.year)
+          appearances += 1
+        } else if (isRunnerUp) {
+          appearances += 1
         }
-        championshipYears.push(season.year)
-        appearances += 1
-      } else if (isCoChampion) {
-        championships += 0.5
-        championshipYears.push(season.year)
-        appearances += 1
-      } else if (isRunnerUp) {
-        appearances += 1
-      }
+      })
     })
 
     return {

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -63,6 +63,14 @@ INSERT INTO team_aliases (team_id, alias) VALUES
   ('a0000000-0000-0000-0000-000000000002', 'Blankland');
 
 -- ============================================
+-- Team Lineage (splits/mergers)
+-- 2 Deep split into Jamaica's Finest and Showtime
+-- ============================================
+INSERT INTO team_lineage (predecessor_id, successor_id, relationship_type, year_occurred, notes) VALUES
+  ('a0000000-0000-0000-0000-000000000018', 'a0000000-0000-0000-0000-000000000007', 'split_into', 2003, '2 Deep split into Jamaica''s Finest and Showtime'),
+  ('a0000000-0000-0000-0000-000000000018', 'a0000000-0000-0000-0000-000000000012', 'split_into', 2003, '2 Deep split into Jamaica''s Finest and Showtime');
+
+-- ============================================
 -- Seasons (28 years: 1998-2025)
 -- ============================================
 INSERT INTO seasons (year, season_number, draft_location_id, champion_id, champion_display_name, runner_up_id, runner_up_display_name, is_co_championship, co_champion_id, notes) VALUES


### PR DESCRIPTION
## Summary
- Add `team_lineage` table to track team splits/mergers for inherited stats
- 2 Deep's 2 runner-up appearances now show for Jamaica's Finest and Showtime
- Co-championships (0.5) display as half-gold bricks in the bar chart

## Test plan
- [ ] Run migration SQL in Supabase to create `team_lineage` table
- [ ] Verify Jamaica's Finest shows 3 appearances (was 1)
- [ ] Verify Showtime shows 4 appearances (was 2)
- [ ] Verify Showtime and Menace show half-gold bricks for their 0.5 championships

🤖 Generated with [Claude Code](https://claude.ai/code)