### PR TITLE
Add authentication with social login and admin page

### DIFF
--- a/api/auth/validate.js
+++ b/api/auth/validate.js
@@ -1,0 +1,62 @@
+import { createClient } from '@supabase/supabase-js'
+
+export default async function handler(req, res) {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { email } = req.body
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' })
+  }
+
+  // Use service key to bypass RLS
+  const supabaseUrl = process.env.VITE_SUPABASE_URL
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    console.error('Missing Supabase environment variables')
+    return res.status(500).json({ error: 'Server configuration error' })
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+  try {
+    // Query for approved owner by joining teams with approved_owners
+    // Check if the email exists in teams.owner_email and has an approved_owners entry
+    const { data, error } = await supabase
+      .from('teams')
+      .select(`
+        id,
+        name,
+        logo,
+        owner_email,
+        approved_owners!inner (
+          id,
+          is_admin
+        )
+      `)
+      .ilike('owner_email', email)
+      .single()
+
+    if (error || !data) {
+      return res.status(200).json({
+        valid: false,
+        message: 'Email not authorized for this league'
+      })
+    }
+
+    return res.status(200).json({
+      valid: true,
+      teamId: data.id,
+      teamName: data.name,
+      teamLogo: data.logo,
+      isAdmin: data.approved_owners?.is_admin || false
+    })
+  } catch (err) {
+    console.error('Validation error:', err)
+    return res.status(500).json({ error: 'Validation failed' })
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,18 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import AppHeader from './components/AppHeader.vue'
 import AppNav from './components/AppNav.vue'
+import LoginModal from './components/LoginModal.vue'
+import { useAuth } from './composables/useAuth'
 
 const isNavOpen = ref(false)
+const isLoginModalOpen = ref(false)
+
+const { initAuth } = useAuth()
+
+onMounted(() => {
+  initAuth()
+})
 
 const toggleNav = () => {
   isNavOpen.value = !isNavOpen.value
@@ -12,12 +21,21 @@ const toggleNav = () => {
 const closeNav = () => {
   isNavOpen.value = false
 }
+
+const openLoginModal = () => {
+  isLoginModalOpen.value = true
+}
+
+const closeLoginModal = () => {
+  isLoginModalOpen.value = false
+}
 </script>
 
 <template>
   <div class="min-h-screen bg-gray-50">
-    <AppHeader @toggle-nav="toggleNav" />
-    <AppNav :is-open="isNavOpen" @close="closeNav" />
+    <AppHeader @toggle-nav="toggleNav" @open-login="openLoginModal" />
+    <AppNav :is-open="isNavOpen" @close="closeNav" @open-login="openLoginModal" />
+    <LoginModal :is-open="isLoginModalOpen" @close="closeLoginModal" />
     <main class="pt-16">
       <router-view />
     </main>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import AppHeader from './components/AppHeader.vue'
 import AppNav from './components/AppNav.vue'
 import LoginModal from './components/LoginModal.vue'
@@ -8,10 +8,18 @@ import { useAuth } from './composables/useAuth'
 const isNavOpen = ref(false)
 const isLoginModalOpen = ref(false)
 
-const { initAuth } = useAuth()
+const { initAuth, error, isAuthenticated } = useAuth()
 
 onMounted(() => {
   initAuth()
+})
+
+// Watch for auth errors and show modal with error message
+watch(error, (newError) => {
+  if (newError && !isAuthenticated.value) {
+    // Re-open the login modal to show the error
+    isLoginModalOpen.value = true
+  }
 })
 
 const toggleNav = () => {

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -36,10 +36,18 @@ watch(isAuthenticated, (authenticated) => {
   }
 })
 
-// Clear errors when modal opens/closes
-watch(() => props.isOpen, (open) => {
-  if (open) {
+// Clear local state when modal closes (but preserve auth errors when opening)
+watch(() => props.isOpen, (open, wasOpen) => {
+  if (!open && wasOpen) {
+    // Modal is closing - clear everything
     clearError()
+    localError.value = ''
+    successMessage.value = ''
+    email.value = ''
+    password.value = ''
+    isSignUp.value = false
+  } else if (open) {
+    // Modal is opening - only clear local errors, keep auth errors visible
     localError.value = ''
     successMessage.value = ''
   }
@@ -124,9 +132,17 @@ const toggleMode = () => {
           <!-- Error message -->
           <div
             v-if="error || localError"
-            class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm"
+            class="mb-4 p-4 bg-red-50 border border-red-300 rounded-lg"
           >
-            {{ error || localError }}
+            <div class="flex items-start gap-3">
+              <svg class="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <div>
+                <p class="text-red-800 font-medium">Access Denied</p>
+                <p class="text-red-700 text-sm mt-1">{{ error || localError }}</p>
+              </div>
+            </div>
           </div>
 
           <!-- Success message -->

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -1,0 +1,274 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { useAuth } from '../composables/useAuth'
+
+const props = defineProps({
+  isOpen: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['close'])
+
+const {
+  loading,
+  error,
+  loginWithGoogle,
+  loginWithMicrosoft,
+  loginWithEmail,
+  signUpWithEmail,
+  clearError,
+  isAuthenticated
+} = useAuth()
+
+const email = ref('')
+const password = ref('')
+const isSignUp = ref(false)
+const localError = ref('')
+const successMessage = ref('')
+
+// Close modal when authenticated
+watch(isAuthenticated, (authenticated) => {
+  if (authenticated) {
+    resetForm()
+    emit('close')
+  }
+})
+
+// Clear errors when modal opens/closes
+watch(() => props.isOpen, (open) => {
+  if (open) {
+    clearError()
+    localError.value = ''
+    successMessage.value = ''
+  }
+})
+
+const resetForm = () => {
+  email.value = ''
+  password.value = ''
+  isSignUp.value = false
+  localError.value = ''
+  successMessage.value = ''
+}
+
+const handleEmailSubmit = async () => {
+  localError.value = ''
+  successMessage.value = ''
+
+  if (!email.value || !password.value) {
+    localError.value = 'Please enter both email and password'
+    return
+  }
+
+  if (password.value.length < 6) {
+    localError.value = 'Password must be at least 6 characters'
+    return
+  }
+
+  if (isSignUp.value) {
+    const result = await signUpWithEmail(email.value, password.value)
+    if (result === 'confirm_email') {
+      successMessage.value = 'Check your email to confirm your account'
+    }
+  } else {
+    await loginWithEmail(email.value, password.value)
+  }
+}
+
+const handleClose = () => {
+  resetForm()
+  clearError()
+  emit('close')
+}
+
+const toggleMode = () => {
+  isSignUp.value = !isSignUp.value
+  localError.value = ''
+  successMessage.value = ''
+  clearError()
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 z-[2000] flex items-center justify-center p-4"
+      >
+        <!-- Backdrop -->
+        <div
+          class="absolute inset-0 bg-black/50"
+          @click="handleClose"
+        />
+
+        <!-- Modal -->
+        <div class="relative bg-white rounded-lg shadow-xl w-full max-w-md p-6">
+          <!-- Close button -->
+          <button
+            @click="handleClose"
+            class="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
+          >
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          <!-- Header -->
+          <h2 class="text-2xl font-bold text-gray-900 mb-6 text-center">
+            {{ isSignUp ? 'Create Account' : 'Welcome Back' }}
+          </h2>
+
+          <!-- Error message -->
+          <div
+            v-if="error || localError"
+            class="mb-4 p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm"
+          >
+            {{ error || localError }}
+          </div>
+
+          <!-- Success message -->
+          <div
+            v-if="successMessage"
+            class="mb-4 p-3 bg-green-50 border border-green-200 rounded-md text-green-700 text-sm"
+          >
+            {{ successMessage }}
+          </div>
+
+          <!-- Social login buttons -->
+          <div class="space-y-3 mb-6">
+            <button
+              @click="loginWithGoogle"
+              :disabled="loading"
+              class="w-full flex items-center justify-center gap-3 bg-white border border-gray-300 rounded-md py-2.5 px-4 text-gray-700 font-medium hover:bg-gray-50 transition-colors disabled:opacity-50"
+            >
+              <svg class="w-5 h-5" viewBox="0 0 24 24">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              Continue with Google
+            </button>
+
+            <button
+              @click="loginWithMicrosoft"
+              :disabled="loading"
+              class="w-full flex items-center justify-center gap-3 bg-white border border-gray-300 rounded-md py-2.5 px-4 text-gray-700 font-medium hover:bg-gray-50 transition-colors disabled:opacity-50"
+            >
+              <svg class="w-5 h-5" viewBox="0 0 23 23">
+                <path fill="#f35325" d="M1 1h10v10H1z"/>
+                <path fill="#81bc06" d="M12 1h10v10H12z"/>
+                <path fill="#05a6f0" d="M1 12h10v10H1z"/>
+                <path fill="#ffba08" d="M12 12h10v10H12z"/>
+              </svg>
+              Continue with Microsoft
+            </button>
+          </div>
+
+          <!-- Divider -->
+          <div class="relative mb-6">
+            <div class="absolute inset-0 flex items-center">
+              <div class="w-full border-t border-gray-300"></div>
+            </div>
+            <div class="relative flex justify-center text-sm">
+              <span class="px-2 bg-white text-gray-500">or</span>
+            </div>
+          </div>
+
+          <!-- Email/Password form -->
+          <form @submit.prevent="handleEmailSubmit" class="space-y-4">
+            <div>
+              <label for="email" class="block text-sm font-medium text-gray-700 mb-1">
+                Email
+              </label>
+              <input
+                id="email"
+                v-model="email"
+                type="email"
+                autocomplete="email"
+                required
+                :disabled="loading"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100"
+                placeholder="owner@example.com"
+              />
+            </div>
+
+            <div>
+              <label for="password" class="block text-sm font-medium text-gray-700 mb-1">
+                Password
+              </label>
+              <input
+                id="password"
+                v-model="password"
+                type="password"
+                :autocomplete="isSignUp ? 'new-password' : 'current-password'"
+                required
+                :disabled="loading"
+                class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:bg-gray-100"
+                placeholder="••••••••"
+              />
+            </div>
+
+            <button
+              type="submit"
+              :disabled="loading"
+              class="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-2.5 px-4 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span v-if="loading" class="flex items-center justify-center gap-2">
+                <svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                  <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                Processing...
+              </span>
+              <span v-else>
+                {{ isSignUp ? 'Create Account' : 'Sign In' }}
+              </span>
+            </button>
+          </form>
+
+          <!-- Toggle sign up / sign in -->
+          <p class="mt-4 text-center text-sm text-gray-600">
+            {{ isSignUp ? 'Already have an account?' : "Don't have an account?" }}
+            <button
+              @click="toggleMode"
+              class="text-blue-600 hover:text-blue-700 font-medium ml-1"
+            >
+              {{ isSignUp ? 'Sign in' : 'Sign up' }}
+            </button>
+          </p>
+
+          <!-- League note -->
+          <p class="mt-4 text-center text-xs text-gray-500">
+            Only authorized league owners can access this site.
+          </p>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.modal-enter-active,
+.modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
+  opacity: 0;
+}
+
+.modal-enter-active .relative,
+.modal-leave-active .relative {
+  transition: transform 0.2s ease;
+}
+
+.modal-enter-from .relative,
+.modal-leave-to .relative {
+  transform: scale(0.95);
+}
+</style>

--- a/src/composables/useAuth.js
+++ b/src/composables/useAuth.js
@@ -1,29 +1,269 @@
 import { ref, computed } from 'vue'
+import { supabase } from './useSupabase'
 
-// Placeholder for future Supabase Auth integration
-// See CLAUDE.md for implementation details
-
+// Shared state (singleton pattern - all components share the same refs)
 const user = ref(null)
-const loading = ref(false)
+const userProfile = ref(null)
+const loading = ref(true)
+const error = ref(null)
+const initialized = ref(false)
 
 export function useAuth() {
   const isAuthenticated = computed(() => !!user.value)
+  const isAdmin = computed(() => userProfile.value?.isAdmin === true)
 
-  const login = async () => {
-    // TODO: Implement Supabase Auth with Google OAuth
-    console.warn('Auth not implemented yet')
+  // Validate email against approved owners
+  const validateEmail = async (email) => {
+    try {
+      const response = await fetch('/api/auth/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      })
+
+      // Handle 404 in development (serverless functions not available)
+      if (response.status === 404) {
+        console.warn('Validation endpoint not available. Using Supabase direct query.')
+        return await validateEmailDirect(email)
+      }
+
+      return await response.json()
+    } catch (err) {
+      console.error('Email validation error:', err)
+      // Fallback to direct Supabase query
+      return await validateEmailDirect(email)
+    }
   }
 
+  // Direct Supabase validation (fallback for local dev)
+  const validateEmailDirect = async (email) => {
+    try {
+      const { data, error } = await supabase
+        .from('teams')
+        .select(`
+          id,
+          name,
+          logo,
+          owner_email,
+          approved_owners!inner (
+            id,
+            is_admin
+          )
+        `)
+        .ilike('owner_email', email)
+        .single()
+
+      if (error || !data) {
+        return {
+          valid: false,
+          message: 'Email not authorized for this league'
+        }
+      }
+
+      return {
+        valid: true,
+        teamId: data.id,
+        teamName: data.name,
+        teamLogo: data.logo,
+        isAdmin: data.approved_owners?.is_admin || false
+      }
+    } catch (err) {
+      console.error('Direct validation error:', err)
+      return { valid: false, message: 'Validation failed' }
+    }
+  }
+
+  // Handle successful auth - validate and set profile
+  const handleAuthSuccess = async (session) => {
+    if (!session?.user?.email) {
+      return false
+    }
+
+    const validation = await validateEmail(session.user.email)
+
+    if (!validation.valid) {
+      // Sign out unauthorized user
+      await supabase.auth.signOut()
+      error.value = validation.message || 'Your email is not authorized for this league'
+      user.value = null
+      userProfile.value = null
+      return false
+    }
+
+    user.value = session.user
+    userProfile.value = {
+      teamId: validation.teamId,
+      teamName: validation.teamName,
+      teamLogo: validation.teamLogo,
+      isAdmin: validation.isAdmin
+    }
+    error.value = null
+    return true
+  }
+
+  // Initialize auth listener
+  const initAuth = async () => {
+    if (initialized.value) return
+
+    loading.value = true
+
+    // Check for existing session
+    const { data: { session } } = await supabase.auth.getSession()
+    if (session) {
+      await handleAuthSuccess(session)
+    }
+
+    // Listen for auth changes
+    supabase.auth.onAuthStateChange(async (event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        await handleAuthSuccess(session)
+      } else if (event === 'SIGNED_OUT') {
+        user.value = null
+        userProfile.value = null
+        error.value = null
+      }
+      loading.value = false
+    })
+
+    initialized.value = true
+    loading.value = false
+  }
+
+  // Login with Google OAuth
+  const loginWithGoogle = async () => {
+    error.value = null
+    loading.value = true
+    try {
+      const { error: authError } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: window.location.origin
+        }
+      })
+      if (authError) throw authError
+    } catch (err) {
+      error.value = err.message
+      loading.value = false
+    }
+  }
+
+  // Login with Microsoft OAuth
+  const loginWithMicrosoft = async () => {
+    error.value = null
+    loading.value = true
+    try {
+      const { error: authError } = await supabase.auth.signInWithOAuth({
+        provider: 'azure',
+        options: {
+          redirectTo: window.location.origin,
+          scopes: 'email openid profile'
+        }
+      })
+      if (authError) throw authError
+    } catch (err) {
+      error.value = err.message
+      loading.value = false
+    }
+  }
+
+  // Login with email/password
+  const loginWithEmail = async (email, password) => {
+    error.value = null
+    loading.value = true
+    try {
+      const { data, error: authError } = await supabase.auth.signInWithPassword({
+        email,
+        password
+      })
+      if (authError) throw authError
+
+      // Validate email after successful auth
+      if (data.session) {
+        const success = await handleAuthSuccess(data.session)
+        if (!success) {
+          loading.value = false
+          return false
+        }
+      }
+      loading.value = false
+      return true
+    } catch (err) {
+      error.value = err.message
+      loading.value = false
+      return false
+    }
+  }
+
+  // Sign up with email/password
+  const signUpWithEmail = async (email, password) => {
+    error.value = null
+    loading.value = true
+    try {
+      // First validate that email is in approved list
+      const validation = await validateEmail(email)
+      if (!validation.valid) {
+        error.value = validation.message || 'Your email is not authorized for this league'
+        loading.value = false
+        return false
+      }
+
+      const { data, error: authError } = await supabase.auth.signUp({
+        email,
+        password
+      })
+      if (authError) throw authError
+
+      // If sign up succeeded and we have a session, validate it
+      if (data.session) {
+        await handleAuthSuccess(data.session)
+      } else if (data.user && !data.session) {
+        // User created but needs email confirmation
+        error.value = null
+        loading.value = false
+        return 'confirm_email'
+      }
+
+      loading.value = false
+      return true
+    } catch (err) {
+      error.value = err.message
+      loading.value = false
+      return false
+    }
+  }
+
+  // Logout
   const logout = async () => {
-    // TODO: Implement Supabase Auth logout
-    console.warn('Auth not implemented yet')
+    loading.value = true
+    try {
+      await supabase.auth.signOut()
+      user.value = null
+      userProfile.value = null
+      error.value = null
+    } catch (err) {
+      error.value = err.message
+    }
+    loading.value = false
+  }
+
+  // Clear error
+  const clearError = () => {
+    error.value = null
   }
 
   return {
     user,
+    userProfile,
     loading,
+    error,
     isAuthenticated,
-    login,
+    isAdmin,
+    initAuth,
+    loginWithGoogle,
+    loginWithMicrosoft,
+    loginWithEmail,
+    signUpWithEmail,
     logout,
+    clearError
   }
 }

--- a/src/pages/AdminPage.vue
+++ b/src/pages/AdminPage.vue
@@ -1,0 +1,38 @@
+<script setup>
+import { useAuth } from '../composables/useAuth'
+import { useRouter } from 'vue-router'
+import { watch } from 'vue'
+
+const { isAdmin, isAuthenticated, loading } = useAuth()
+const router = useRouter()
+
+// Redirect if not admin (backup protection, route guard handles primary check)
+watch([isAdmin, loading], ([admin, isLoading]) => {
+  if (!isLoading && !admin) {
+    router.push('/')
+  }
+}, { immediate: true })
+</script>
+
+<template>
+  <div class="py-8 px-4">
+    <div class="max-w-4xl mx-auto">
+      <h1 class="text-3xl font-bold text-gray-900 mb-2">Admin Dashboard</h1>
+      <p class="text-gray-600 mb-8">Manage league data and settings</p>
+
+      <div class="bg-white rounded-lg shadow-md p-6">
+        <div class="text-center py-12">
+          <svg class="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <h2 class="text-xl font-semibold text-gray-700 mb-2">Admin Features Coming Soon</h2>
+          <p class="text-gray-500 max-w-md mx-auto">
+            This area will be used for managing team information, updating season data,
+            and other administrative tasks.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,8 @@ import DraftsPage from '../pages/DraftsPage.vue'
 import DraftDetailPage from '../pages/DraftDetailPage.vue'
 import TeamsPage from '../pages/TeamsPage.vue'
 import AboutPage from '../pages/AboutPage.vue'
+import AdminPage from '../pages/AdminPage.vue'
+import { useAuth } from '../composables/useAuth'
 
 const routes = [
   { path: '/', name: 'Home', component: HomePage },
@@ -13,11 +15,47 @@ const routes = [
   { path: '/drafts/:year', name: 'DraftDetail', component: DraftDetailPage },
   { path: '/teams', name: 'Teams', component: TeamsPage },
   { path: '/about', name: 'About', component: AboutPage },
+  {
+    path: '/admin',
+    name: 'Admin',
+    component: AdminPage,
+    meta: { requiresAuth: true, requiresAdmin: true }
+  },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+// Navigation guard for protected routes
+router.beforeEach((to, from, next) => {
+  const { isAuthenticated, isAdmin, loading } = useAuth()
+
+  // Check if route requires authentication
+  if (to.meta.requiresAuth) {
+    // Wait for auth to initialize if still loading
+    if (loading.value) {
+      // Auth still initializing, allow navigation (component will handle redirect)
+      next()
+      return
+    }
+
+    if (!isAuthenticated.value) {
+      // Not authenticated, redirect to home
+      next({ name: 'Home' })
+      return
+    }
+
+    // Check if route requires admin
+    if (to.meta.requiresAdmin && !isAdmin.value) {
+      // Not admin, redirect to home
+      next({ name: 'Home' })
+      return
+    }
+  }
+
+  next()
 })
 
 export default router


### PR DESCRIPTION
## Summary

- Add Supabase Auth integration with Google OAuth, Microsoft OAuth, and email/password login
- Create login modal with social login buttons and email/password form
- Add serverless validation function to verify emails against approved_owners table
- Add protected Admin page accessible only to users with is_admin flag
- Display team logo and name in navigation when logged in
- Show "Access Denied" error for unauthorized login attempts

## Features

- **Login Button**: Blue button in nav bar opens login modal
- **Social Login**: Google and Microsoft OAuth support
- **Email/Password**: Sign up and sign in with email/password for non-social accounts
- **Authorization**: Only emails in teams.owner_email with approved_owners entry can log in
- **Admin Access**: Users with is_admin=true see Admin nav item and can access /admin route
- **Team Display**: Logged-in users see their team logo and name in nav

## Test plan

- [ ] Click Login button - modal should open
- [ ] Test Google OAuth with authorized email - should log in successfully
- [ ] Test Microsoft OAuth with authorized email - should log in successfully
- [ ] Test OAuth with unauthorized email - should show "Access Denied" error
- [ ] Test email/password sign up with authorized email
- [ ] Verify team logo and name appear in nav after login
- [ ] Verify Admin link only appears for admin users
- [ ] Verify /admin route redirects non-admins to home
- [ ] Test logout functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)