### PR TITLE
Draft detail page: Labor Day dates, hero photo, label updates

### DIFF
--- a/src/components/photos/DraftPhotoGrid.vue
+++ b/src/components/photos/DraftPhotoGrid.vue
@@ -73,11 +73,10 @@ const confirmDelete = (photo) => {
           <p class="text-white text-sm truncate">{{ photo.caption }}</p>
         </div>
 
-        <!-- Hero photo badge (filled gold star, always visible) -->
+        <!-- Hero photo badge (filled gold star, admin only) -->
         <div
-          v-if="photo.id === heroPhotoId"
-          class="absolute top-2 left-2 bg-amber-500 text-white p-1.5 rounded-full shadow-md"
-          :class="isAdmin ? 'cursor-pointer' : ''"
+          v-if="isAdmin && photo.id === heroPhotoId"
+          class="absolute top-2 left-2 bg-amber-500 text-white p-1.5 rounded-full shadow-md cursor-pointer"
           title="Hero photo"
         >
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">

--- a/src/components/photos/DraftPhotoGrid.vue
+++ b/src/components/photos/DraftPhotoGrid.vue
@@ -7,10 +7,18 @@ defineProps({
   loading: {
     type: Boolean,
     default: false
+  },
+  isAdmin: {
+    type: Boolean,
+    default: false
+  },
+  heroPhotoId: {
+    type: String,
+    default: null
   }
 })
 
-const emit = defineEmits(['open-lightbox', 'delete'])
+const emit = defineEmits(['open-lightbox', 'delete', 'set-hero'])
 
 const openLightbox = (index) => {
   emit('open-lightbox', index)
@@ -64,6 +72,30 @@ const confirmDelete = (photo) => {
         >
           <p class="text-white text-sm truncate">{{ photo.caption }}</p>
         </div>
+
+        <!-- Hero photo badge (filled gold star, always visible) -->
+        <div
+          v-if="photo.id === heroPhotoId"
+          class="absolute top-2 left-2 bg-amber-500 text-white p-1.5 rounded-full shadow-md"
+          :class="isAdmin ? 'cursor-pointer' : ''"
+          title="Hero photo"
+        >
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+          </svg>
+        </div>
+
+        <!-- Set as hero button (outline star on hover, admin only) -->
+        <button
+          v-if="isAdmin && photo.id !== heroPhotoId"
+          @click.stop="emit('set-hero', photo)"
+          class="absolute top-2 left-2 bg-white/80 text-amber-500 p-1.5 rounded-full opacity-0 group-hover:opacity-100 transition-opacity hover:bg-amber-500 hover:text-white"
+          title="Set as hero photo"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+          </svg>
+        </button>
 
         <!-- Delete button (only for owner's photos) -->
         <button

--- a/src/composables/useChampionshipData.js
+++ b/src/composables/useChampionshipData.js
@@ -52,7 +52,8 @@ export function useChampionshipData() {
         coChampion: season.co_champion,  // Keep full co-champion object
         runnerUp: season.runner_up_display_name || season.runner_up?.name || '------',
         note: season.notes,
-        isCoChampionship: season.is_co_championship
+        isCoChampionship: season.is_co_championship,
+        groupPhotoId: season.group_photo_id || null
       }))
 
       // Filter out Virtual from map (no coordinates)

--- a/src/services/seasonService.js
+++ b/src/services/seasonService.js
@@ -125,6 +125,21 @@ export async function getDraftLocations() {
 }
 
 /**
+ * Set the group/hero photo for a season
+ * @param {string} seasonId - Season UUID
+ * @param {string|null} photoId - draft_photos.id or null to unset
+ * @returns {Promise<{success: boolean, error: Error|null}>}
+ */
+export async function setGroupPhoto(seasonId, photoId) {
+  const { error } = await supabase
+    .from('seasons')
+    .update({ group_photo_id: photoId })
+    .eq('id', seasonId)
+
+  return { success: !error, error }
+}
+
+/**
  * Get championship statistics
  * Includes inherited stats from predecessor teams
  * @returns {Promise<{data: Object|null, error: Error|null}>}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -115,6 +115,10 @@ CREATE TABLE draft_photos (
 -- Index for fetching photos by season
 CREATE INDEX idx_draft_photos_season ON draft_photos(season_id);
 
+-- Add group photo reference to seasons (after draft_photos table exists)
+ALTER TABLE seasons
+  ADD COLUMN group_photo_id uuid REFERENCES draft_photos(id) ON DELETE SET NULL;
+
 -- ============================================
 -- Row Level Security (RLS) Policies
 -- Public read, authenticated write


### PR DESCRIPTION
## Summary
- Display Labor Day weekend dates (Friday - Monday) under the draft year heading
- Add admin-only hero photo selection via star icon on photo grid thumbnails — clicking sets the photo as the full-width hero image in the header card
- Rename "Runner Up" / "Champion" labels to "End of Season Runner Up" / "End of Season Champion"
- Add `group_photo_id` column to seasons schema (requires manual ALTER TABLE on Supabase)

## Test plan
- [ ] Navigate to a draft detail page and verify Labor Day weekend dates display correctly
- [ ] Log in as admin, click star icon on a photo to set it as hero — verify it appears in the header card
- [ ] Navigate away and back — verify hero photo persists
- [ ] Click star on a different photo — verify hero switches
- [ ] Verify non-admin users do not see any star icons
- [ ] Verify "End of Season Runner Up" and "End of Season Champion" labels display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)