### PR TITLE
Add draft position history feature

### DIFF
--- a/src/composables/useDraftPositionData.js
+++ b/src/composables/useDraftPositionData.js
@@ -1,0 +1,100 @@
+import { ref, computed, onMounted } from 'vue'
+import { getDraftPositions } from '../services/draftPositionService'
+
+export function useDraftPositionData() {
+  const positions = ref([])
+  const loading = ref(true)
+  const error = ref(null)
+
+  const fetchPositions = async () => {
+    try {
+      loading.value = true
+      error.value = null
+
+      const { data, error: fetchError } = await getDraftPositions()
+
+      if (fetchError) {
+        throw new Error(fetchError.message)
+      }
+
+      positions.value = data || []
+    } catch (e) {
+      error.value = e.message
+      console.error('Error fetching draft positions:', e)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  onMounted(fetchPositions)
+
+  // Get unique years from the data, sorted
+  const years = computed(() => {
+    const yearSet = new Set(positions.value.map(p => p.season?.year).filter(Boolean))
+    return [...yearSet].sort((a, b) => a - b)
+  })
+
+  // Get unique teams from the data, sorted by name
+  const teams = computed(() => {
+    const teamMap = new Map()
+    positions.value.forEach(p => {
+      if (p.team && !teamMap.has(p.team.id)) {
+        teamMap.set(p.team.id, p.team)
+      }
+    })
+    return [...teamMap.values()].sort((a, b) => a.name.localeCompare(b.name))
+  })
+
+  // Pivot to grid format: { teamId: { year: position } }
+  const positionGrid = computed(() => {
+    const grid = {}
+    positions.value.forEach(p => {
+      if (!p.team || !p.season) return
+      if (!grid[p.team.id]) {
+        grid[p.team.id] = { team: p.team, positions: {} }
+      }
+      grid[p.team.id].positions[p.season.year] = p.draft_position
+    })
+    return grid
+  })
+
+  // Calculate stats per team
+  const teamStats = computed(() => {
+    const stats = []
+
+    teams.value.forEach(team => {
+      const teamPositions = positions.value
+        .filter(p => p.team?.id === team.id)
+        .map(p => p.draft_position)
+
+      if (teamPositions.length === 0) return
+
+      const avgPosition = teamPositions.reduce((a, b) => a + b, 0) / teamPositions.length
+      const firstPicks = teamPositions.filter(p => p === 1).length
+      const lastPicks = teamPositions.filter(p => p === 14).length
+      const top5Picks = teamPositions.filter(p => p <= 5).length
+
+      stats.push({
+        team,
+        avgPosition: Math.round(avgPosition * 10) / 10,
+        firstPicks,
+        lastPicks,
+        top5Picks,
+        totalDrafts: teamPositions.length
+      })
+    })
+
+    return stats.sort((a, b) => a.avgPosition - b.avgPosition)
+  })
+
+  return {
+    positions,
+    years,
+    teams,
+    positionGrid,
+    teamStats,
+    loading,
+    error,
+    refetch: fetchPositions
+  }
+}

--- a/src/pages/DraftsPage.vue
+++ b/src/pages/DraftsPage.vue
@@ -1,12 +1,124 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { RouterLink } from 'vue-router'
 import 'leaflet/dist/leaflet.css'
 import { LMap, LTileLayer, LMarker, LPopup } from '@vue-leaflet/vue-leaflet'
 import { useChampionshipData } from '../composables/useChampionshipData'
+import { useDraftPositionData } from '../composables/useDraftPositionData'
 
 const { seasons, draftLocations, loading, error } = useChampionshipData()
+const {
+  years: draftYears,
+  positionGrid,
+  teamStats,
+  loading: positionsLoading
+} = useDraftPositionData()
 const mapRef = ref(null)
+
+// Import all logo images dynamically
+const logoModules = import.meta.glob('@/assets/*.{jpg,png}', { eager: true })
+
+const getLogoUrl = (logoFile) => {
+  if (!logoFile) return null
+  for (const [key, module] of Object.entries(logoModules)) {
+    if (key.endsWith(logoFile)) {
+      return module.default
+    }
+  }
+  return null
+}
+
+// All years from 2003 to current year (to show gaps)
+const allYears = computed(() => {
+  if (!draftYears.value.length) return []
+  const minYear = Math.min(...draftYears.value)
+  const maxYear = Math.max(...draftYears.value)
+  const years = []
+  for (let y = minYear; y <= maxYear; y++) {
+    years.push(y)
+  }
+  return years
+})
+
+// Format year with tick mark
+const formatYear = (year) => `'${String(year).slice(-2)}`
+
+// Get champion team ID for a given year
+const getChampionId = (year) => {
+  const season = seasons.value?.find(s => s.year === year)
+  return season?.champion?.id || null
+}
+
+// Get position cell class with champion highlight
+const getPositionClass = (position, teamId, year) => {
+  const isChampion = getChampionId(year) === teamId
+  let classes = []
+
+  if (position === 1) {
+    classes.push('bg-amber-100 text-amber-800 font-bold')
+  } else if (position === 14) {
+    classes.push('bg-gray-200 text-gray-600')
+  } else {
+    classes.push('text-gray-700')
+  }
+
+  if (isChampion && position) {
+    classes.push('ring-2 ring-amber-500 ring-inset')
+  }
+
+  return classes.join(' ')
+}
+
+// Teams that have never had #1 pick
+const neverFirstPick = computed(() => {
+  return teamStats.value.filter(s => s.firstPicks === 0)
+})
+
+// Teams that have never had last pick
+const neverLastPick = computed(() => {
+  return teamStats.value.filter(s => s.lastPicks === 0)
+})
+
+// Team name with asterisks for special notes (in alphabetical order: Jamaica's Finest, Junkyard Dawgs, Showtime)
+const getTeamDisplayName = (teamName) => {
+  if (teamName === "Jamaica's Finest") return `${teamName}*`
+  if (teamName === 'Junkyard Dawgs') return `${teamName}**`
+  if (teamName === 'Showtime') return `${teamName}***`
+  return teamName
+}
+
+// Team stats sorted alphabetically for the grid
+const teamStatsAlphabetical = computed(() => {
+  return [...teamStats.value].sort((a, b) => a.team.name.localeCompare(b.team.name))
+})
+
+// Teams with most/least top 5 picks
+const mostTop5Picks = computed(() => {
+  if (!teamStats.value.length) return null
+  return teamStats.value.reduce((a, b) => a.top5Picks > b.top5Picks ? a : b)
+})
+
+const leastTop5Picks = computed(() => {
+  if (!teamStats.value.length) return null
+  return teamStats.value.reduce((a, b) => a.top5Picks < b.top5Picks ? a : b)
+})
+
+// Average draft position for champions
+const avgChampionDraftPosition = computed(() => {
+  if (!seasons.value?.length || !positionGrid.value) return null
+
+  const championPositions = []
+  seasons.value.forEach(season => {
+    const championId = season.champion?.id
+    if (championId && positionGrid.value[championId]?.positions[season.year]) {
+      championPositions.push(positionGrid.value[championId].positions[season.year])
+    }
+  })
+
+  if (championPositions.length === 0) return null
+  const avg = championPositions.reduce((a, b) => a + b, 0) / championPositions.length
+  return Math.round(avg * 10) / 10
+})
 
 // Map configuration - centered on continental US
 const defaultCenter = [39.5, -98.35]
@@ -26,22 +138,36 @@ const resetMap = () => {
     mapRef.value.leafletObject.setView(defaultCenter, getDefaultZoom())
   }
 }
-
-// Championship data is fetched automatically by useChampionshipData composable
-// Virtual locations are already filtered out in the composable
 </script>
 
 <template>
   <div class="py-8 px-4">
     <div class="max-w-6xl mx-auto">
-      <h1 class="text-2xl font-bold mb-6 text-center">Draft Locations</h1>
+      <h1 class="text-2xl font-bold mb-4 text-center">Drafts</h1>
 
-      <div v-if="loading" class="text-center py-8">Loading map...</div>
+      <!-- Quick Navigation -->
+      <div class="flex flex-wrap justify-center gap-2 mb-6">
+        <a href="#locations" class="px-4 py-2 bg-white rounded-lg shadow-sm border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-obl-accent transition-colors">
+          Locations
+        </a>
+        <a href="#all-drafts" class="px-4 py-2 bg-white rounded-lg shadow-sm border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-obl-accent transition-colors">
+          All Drafts
+        </a>
+        <a href="#stats" class="px-4 py-2 bg-white rounded-lg shadow-sm border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-obl-accent transition-colors">
+          Stats
+        </a>
+        <a href="#history" class="px-4 py-2 bg-white rounded-lg shadow-sm border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 hover:border-obl-accent transition-colors">
+          Position History
+        </a>
+      </div>
+
+      <div v-if="loading" class="text-center py-8">Loading...</div>
       <div v-else-if="error" class="text-red-500 py-8 text-center">{{ error }}</div>
 
       <template v-else>
         <!-- Map -->
-        <div class="relative rounded-lg overflow-hidden shadow-lg border border-gray-200 mb-8">
+        <div id="locations" class="relative rounded-lg overflow-hidden shadow-lg border border-gray-200 mb-8 scroll-mt-4">
+          <h2 class="sr-only">Draft Locations Map</h2>
           <!-- Home Button -->
           <button
             @click="resetMap"
@@ -94,17 +220,255 @@ const resetMap = () => {
         </div>
 
         <!-- Draft List -->
-        <h2 class="text-xl font-bold mb-4">All Drafts</h2>
-        <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3">
-          <RouterLink
-            v-for="season in seasons"
-            :key="season.year"
-            :to="`/drafts/${season.year}`"
-            class="bg-white rounded-lg shadow-md p-3 text-center hover:shadow-lg hover:scale-105 transition-all border border-gray-200"
-          >
-            <div class="text-lg font-bold text-obl-header">{{ season.year }}</div>
-            <div class="text-xs text-gray-500">{{ season.draftLocation }}</div>
-          </RouterLink>
+        <div id="all-drafts" class="scroll-mt-4">
+          <h2 class="text-xl font-bold mb-4">All Drafts</h2>
+          <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3 mb-8">
+            <RouterLink
+              v-for="season in seasons"
+              :key="season.year"
+              :to="`/drafts/${season.year}`"
+              class="bg-white rounded-lg shadow-md p-3 text-center hover:shadow-lg hover:scale-105 transition-all border border-gray-200"
+            >
+              <div class="text-lg font-bold text-obl-header">{{ season.year }}</div>
+              <div class="text-xs text-gray-500">{{ season.draftLocation }}</div>
+            </RouterLink>
+          </div>
+        </div>
+
+        <!-- Draft Position Stats -->
+        <div v-if="!positionsLoading && teamStats.length" id="stats" class="mb-8 scroll-mt-4">
+          <h2 class="text-xl font-bold mb-4">Draft Position Stats</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <!-- Best Avg Position -->
+            <div class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Best Avg Draft Position</div>
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="getLogoUrl(teamStats[0]?.team?.logo)"
+                  :src="getLogoUrl(teamStats[0]?.team?.logo)"
+                  :alt="teamStats[0]?.team?.name"
+                  class="w-10 h-10 rounded-full object-cover"
+                />
+                <div>
+                  <div class="font-bold">{{ teamStats[0]?.team?.name }}</div>
+                  <div class="text-obl-accent text-lg font-semibold">{{ teamStats[0]?.avgPosition }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Worst Avg Position -->
+            <div class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Worst Avg Draft Position</div>
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="getLogoUrl(teamStats[teamStats.length - 1]?.team?.logo)"
+                  :src="getLogoUrl(teamStats[teamStats.length - 1]?.team?.logo)"
+                  :alt="teamStats[teamStats.length - 1]?.team?.name"
+                  class="w-10 h-10 rounded-full object-cover"
+                />
+                <div>
+                  <div class="font-bold">{{ teamStats[teamStats.length - 1]?.team?.name }}</div>
+                  <div class="text-gray-600 text-lg font-semibold">{{ teamStats[teamStats.length - 1]?.avgPosition }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Most #1 Picks -->
+            <div class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Most #1 Picks</div>
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="getLogoUrl(teamStats.reduce((a, b) => a.firstPicks > b.firstPicks ? a : b)?.team?.logo)"
+                  :src="getLogoUrl(teamStats.reduce((a, b) => a.firstPicks > b.firstPicks ? a : b)?.team?.logo)"
+                  :alt="teamStats.reduce((a, b) => a.firstPicks > b.firstPicks ? a : b)?.team?.name"
+                  class="w-10 h-10 rounded-full object-cover"
+                />
+                <div>
+                  <div class="font-bold">{{ teamStats.reduce((a, b) => a.firstPicks > b.firstPicks ? a : b)?.team?.name }}</div>
+                  <div class="text-amber-600 text-lg font-semibold">{{ teamStats.reduce((a, b) => a.firstPicks > b.firstPicks ? a : b)?.firstPicks }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Most Last Picks -->
+            <div class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Most Last Picks</div>
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="getLogoUrl(teamStats.reduce((a, b) => a.lastPicks > b.lastPicks ? a : b)?.team?.logo)"
+                  :src="getLogoUrl(teamStats.reduce((a, b) => a.lastPicks > b.lastPicks ? a : b)?.team?.logo)"
+                  :alt="teamStats.reduce((a, b) => a.lastPicks > b.lastPicks ? a : b)?.team?.name"
+                  class="w-10 h-10 rounded-full object-cover"
+                />
+                <div>
+                  <div class="font-bold">{{ teamStats.reduce((a, b) => a.lastPicks > b.lastPicks ? a : b)?.team?.name }}</div>
+                  <div class="text-gray-600 text-lg font-semibold">{{ teamStats.reduce((a, b) => a.lastPicks > b.lastPicks ? a : b)?.lastPicks }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Avg Champion Draft Position -->
+            <div v-if="avgChampionDraftPosition" class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Avg Champion Draft Position</div>
+              <div class="flex items-center gap-3">
+                <div class="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center">
+                  <svg class="w-6 h-6 text-amber-600" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+                  </svg>
+                </div>
+                <div>
+                  <div class="font-bold">Champions</div>
+                  <div class="text-amber-600 text-lg font-semibold">{{ avgChampionDraftPosition }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Most Top 5 Picks -->
+            <div v-if="mostTop5Picks" class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Most Top 5 Picks</div>
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="getLogoUrl(mostTop5Picks.team?.logo)"
+                  :src="getLogoUrl(mostTop5Picks.team?.logo)"
+                  :alt="mostTop5Picks.team?.name"
+                  class="w-10 h-10 rounded-full object-cover"
+                />
+                <div>
+                  <div class="font-bold">{{ mostTop5Picks.team?.name }}</div>
+                  <div class="text-obl-accent text-lg font-semibold">{{ mostTop5Picks.top5Picks }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Least Top 5 Picks -->
+            <div v-if="leastTop5Picks" class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Fewest Top 5 Picks</div>
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="getLogoUrl(leastTop5Picks.team?.logo)"
+                  :src="getLogoUrl(leastTop5Picks.team?.logo)"
+                  :alt="leastTop5Picks.team?.name"
+                  class="w-10 h-10 rounded-full object-cover"
+                />
+                <div>
+                  <div class="font-bold">{{ leastTop5Picks.team?.name }}</div>
+                  <div class="text-gray-600 text-lg font-semibold">{{ leastTop5Picks.top5Picks }}</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Never Had #1 Pick -->
+            <div v-if="neverFirstPick.length" class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Never Had #1 Pick</div>
+              <div class="flex flex-wrap gap-2">
+                <div
+                  v-for="stat in neverFirstPick"
+                  :key="stat.team.id"
+                  class="flex items-center gap-1"
+                >
+                  <img
+                    v-if="getLogoUrl(stat.team.logo)"
+                    :src="getLogoUrl(stat.team.logo)"
+                    :alt="stat.team.name"
+                    class="w-6 h-6 rounded-full object-cover"
+                  />
+                  <span class="text-sm font-medium">{{ stat.team.name }}</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Never Drafted Last -->
+            <div v-if="neverLastPick.length" class="bg-white rounded-lg shadow-md p-4 border border-gray-200">
+              <div class="text-sm text-gray-500 mb-2">Never Drafted Last</div>
+              <div class="flex flex-wrap gap-2">
+                <div
+                  v-for="stat in neverLastPick"
+                  :key="stat.team.id"
+                  class="flex items-center gap-1"
+                >
+                  <img
+                    v-if="getLogoUrl(stat.team.logo)"
+                    :src="getLogoUrl(stat.team.logo)"
+                    :alt="stat.team.name"
+                    class="w-6 h-6 rounded-full object-cover"
+                  />
+                  <span class="text-sm font-medium">{{ stat.team.name }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Draft Position Grid -->
+        <div v-if="!positionsLoading && allYears.length" id="history" class="mb-8 scroll-mt-4">
+          <h2 class="text-xl font-bold mb-4">Draft Position History</h2>
+
+          <div class="bg-white rounded-lg shadow-md border border-gray-200 overflow-x-auto">
+            <table class="min-w-full text-sm">
+              <thead>
+                <tr class="bg-gray-50">
+                  <th class="sticky left-0 bg-gray-50 px-3 py-1 text-left font-semibold text-gray-900 border-r border-gray-200" rowspan="2">Team</th>
+                  <th class="sticky left-[140px] bg-gray-50 px-2 py-1 text-center font-semibold text-gray-900 border-r border-gray-200" rowspan="2">Avg</th>
+                  <th
+                    :colspan="allYears.length"
+                    class="px-2 py-1 text-center font-semibold text-gray-500 border-b border-gray-200"
+                  >
+                    Year
+                  </th>
+                </tr>
+                <tr class="bg-gray-50">
+                  <th
+                    v-for="year in allYears"
+                    :key="year"
+                    class="px-1 py-1 text-center font-medium text-gray-600 whitespace-nowrap text-xs"
+                  >
+                    {{ formatYear(year) }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="stat in teamStatsAlphabetical"
+                  :key="stat.team.id"
+                  class="border-t border-gray-100 hover:bg-gray-50"
+                >
+                  <td class="sticky left-0 bg-white px-3 py-2 border-r border-gray-200">
+                    <div class="flex items-center gap-2">
+                      <img
+                        v-if="getLogoUrl(stat.team.logo)"
+                        :src="getLogoUrl(stat.team.logo)"
+                        :alt="stat.team.name"
+                        class="w-6 h-6 rounded-full object-cover flex-shrink-0"
+                      />
+                      <span class="font-medium whitespace-nowrap text-xs">{{ getTeamDisplayName(stat.team.name) }}</span>
+                    </div>
+                  </td>
+                  <td class="sticky left-[140px] bg-white px-2 py-2 text-center font-semibold text-obl-accent border-r border-gray-200 text-xs">
+                    {{ stat.avgPosition }}
+                  </td>
+                  <td
+                    v-for="year in allYears"
+                    :key="year"
+                    class="px-1 py-2 text-center text-xs"
+                    :class="getPositionClass(positionGrid[stat.team.id]?.positions[year], stat.team.id, year)"
+                  >
+                    {{ positionGrid[stat.team.id]?.positions[year] || '-' }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Legend and Notes -->
+          <div class="mt-3 text-xs text-gray-500 space-y-1">
+            <p>
+              <span class="inline-block w-4 h-4 ring-2 ring-amber-500 ring-inset align-middle mr-1"></span>
+              Gold outline indicates the team won the championship that year
+            </p>
+            <p>* Jamaica's Finest: Draft positions prior to 2011 are attributable to Stealth Bombers</p>
+            <p>** Junkyard Dawgs: Draft positions prior to 2013 are attributable to Cornball Hustlers</p>
+            <p>*** Showtime: Draft positions prior to 2011 are attributable to 2 Deep</p>
+          </div>
         </div>
       </template>
     </div>

--- a/src/services/draftPositionService.js
+++ b/src/services/draftPositionService.js
@@ -1,0 +1,57 @@
+import { supabase } from '../composables/useSupabase'
+
+/**
+ * Fetch all draft positions with team and season data (for grid display)
+ * @returns {Promise<{data: Array, error: Error|null}>}
+ */
+export async function getDraftPositions() {
+  const { data, error } = await supabase
+    .from('draft_positions')
+    .select(`
+      id,
+      draft_position,
+      team:teams(id, name, logo),
+      season:seasons(id, year)
+    `)
+    .order('draft_position')
+
+  return { data, error }
+}
+
+/**
+ * Fetch draft positions for a specific season (for detail page)
+ * @param {string} seasonId - Season UUID
+ * @returns {Promise<{data: Array, error: Error|null}>}
+ */
+export async function getDraftPositionsBySeason(seasonId) {
+  const { data, error } = await supabase
+    .from('draft_positions')
+    .select(`
+      id,
+      draft_position,
+      team:teams(id, name, logo)
+    `)
+    .eq('season_id', seasonId)
+    .order('draft_position')
+
+  return { data, error }
+}
+
+/**
+ * Fetch draft positions for a specific team
+ * @param {string} teamId - Team UUID
+ * @returns {Promise<{data: Array, error: Error|null}>}
+ */
+export async function getDraftPositionsByTeam(teamId) {
+  const { data, error } = await supabase
+    .from('draft_positions')
+    .select(`
+      id,
+      draft_position,
+      season:seasons(id, year)
+    `)
+    .eq('team_id', teamId)
+    .order('season(year)')
+
+  return { data, error }
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -121,6 +121,22 @@ ALTER TABLE seasons
   ADD COLUMN group_photo_id uuid REFERENCES draft_photos(id) ON DELETE SET NULL;
 
 -- ============================================
+-- Table: draft_positions
+-- Draft order for each team per season
+-- ============================================
+CREATE TABLE draft_positions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id uuid NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  season_id uuid NOT NULL REFERENCES seasons(id) ON DELETE CASCADE,
+  draft_position integer NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  UNIQUE(team_id, season_id)
+);
+
+CREATE INDEX idx_draft_positions_team ON draft_positions(team_id);
+CREATE INDEX idx_draft_positions_season ON draft_positions(season_id);
+
+-- ============================================
 -- Row Level Security (RLS) Policies
 -- Public read, authenticated write
 -- ============================================
@@ -133,6 +149,7 @@ ALTER TABLE team_lineage ENABLE ROW LEVEL SECURITY;
 ALTER TABLE seasons ENABLE ROW LEVEL SECURITY;
 ALTER TABLE approved_owners ENABLE ROW LEVEL SECURITY;
 ALTER TABLE draft_photos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE draft_positions ENABLE ROW LEVEL SECURITY;
 
 -- Public read access for all tables
 CREATE POLICY "Public read access" ON draft_locations FOR SELECT USING (true);
@@ -161,3 +178,8 @@ CREATE POLICY "Authenticated update" ON seasons FOR UPDATE USING (auth.role() = 
 CREATE POLICY "Authenticated insert" ON draft_photos FOR INSERT WITH CHECK (auth.role() = 'authenticated');
 CREATE POLICY "Authenticated update" ON draft_photos FOR UPDATE USING (auth.role() = 'authenticated');
 CREATE POLICY "Authenticated delete" ON draft_photos FOR DELETE USING (auth.role() = 'authenticated');
+
+CREATE POLICY "Public read access" ON draft_positions FOR SELECT USING (true);
+CREATE POLICY "Authenticated insert" ON draft_positions FOR INSERT WITH CHECK (auth.role() = 'authenticated');
+CREATE POLICY "Authenticated update" ON draft_positions FOR UPDATE USING (auth.role() = 'authenticated');
+CREATE POLICY "Authenticated delete" ON draft_positions FOR DELETE USING (auth.role() = 'authenticated');

--- a/supabase/seed_draft_positions.sql
+++ b/supabase/seed_draft_positions.sql
@@ -1,0 +1,538 @@
+-- Seed data for draft_positions table
+-- Generated from OBL Draft Position History.csv
+-- Missing years: 2006, 2008, 2019, 2020, 2023
+
+-- Insert draft positions using team name and season year lookups
+-- Each INSERT finds the team_id and season_id dynamically
+
+-- Jamaica's Finest
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Jamaica''s Finest' AND s.year = 2025;
+
+-- Junkyard Dawgs
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Junkyard Dawgs' AND s.year = 2025;
+
+-- Outta Control
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Outta Control' AND s.year = 2025;
+
+-- Menace
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Menace' AND s.year = 2025;
+
+-- Showtime
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Showtime' AND s.year = 2025;
+
+-- Hampton Ballers
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Hampton Ballers' AND s.year = 2025;
+
+-- Skindeep Ballaz
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Skindeep Ballaz' AND s.year = 2025;
+
+-- Blank
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Blank' AND s.year = 2025;
+
+-- Gunslingers
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Gunslingers' AND s.year = 2025;
+
+-- Makaveli
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Makaveli' AND s.year = 2025;
+
+-- Burghman
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Burghman' AND s.year = 2025;
+
+-- AMW
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'AMW' AND s.year = 2025;
+
+-- Birrrdy
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 12 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 9 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 8 FROM teams t, seasons s WHERE t.name = 'Birrrdy' AND s.year = 2025;
+
+-- Stout
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 7 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2003;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2004;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2005;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2007;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 11 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2009;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2010;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2011;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 3 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2012;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 5 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2013;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2014;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 10 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2015;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 4 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2016;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2017;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 6 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2018;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 2 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2021;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 14 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2022;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 1 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2024;
+INSERT INTO draft_positions (team_id, season_id, draft_position)
+SELECT t.id, s.id, 13 FROM teams t, seasons s WHERE t.name = 'Stout' AND s.year = 2025;


### PR DESCRIPTION
## Summary
- Add `draft_positions` database table to store historical draft order data
- Create service layer and composable for fetching/computing draft position stats
- Display horizontal draft order with team logos on individual draft detail pages
- Add comprehensive draft stats section to Drafts page with multiple stat cards
- Add full draft position history grid with champion highlights and team footnotes

## New Stats Cards
- Best/Worst Average Draft Position
- Most #1 Picks / Most Last Picks
- Most/Fewest Top 5 Picks
- Never Had #1 Pick / Never Drafted Last
- Average Champion Draft Position

## Draft Position History Grid
- All years from 2003-2025 (missing years shown as dashes)
- Teams sorted alphabetically
- Gold outline highlights championship-winning team for each year
- Footnotes for teams with inherited draft positions (Jamaica's Finest, Junkyard Dawgs, Showtime)

## Test plan
- [ ] Run CREATE TABLE SQL in Supabase SQL Editor
- [ ] Run seed_draft_positions.sql to populate data
- [ ] Verify `/drafts` page shows stats cards and position history grid
- [ ] Verify `/drafts/2024` shows horizontal draft order with logos
- [ ] Verify champion cells have gold outline in grid
- [ ] Verify quick nav buttons scroll to correct sections
- [ ] Verify years with no data show "-" in grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)