### PR TITLE
Add years since last title table and new stat cards

### DIFF
--- a/src/components/champions/ChampionshipStats.vue
+++ b/src/components/champions/ChampionshipStats.vue
@@ -8,7 +8,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="grid grid-cols-2 lg:grid-cols-5 gap-4 mb-8">
+  <div class="grid grid-cols-2 lg:grid-cols-6 gap-4 mb-8">
     <!-- Total Seasons -->
     <div class="bg-white rounded-lg shadow-md p-4 text-center border-t-4 border-obl-header">
       <div class="text-3xl font-bold text-obl-header">{{ stats.totalSeasons }}</div>
@@ -24,23 +24,35 @@ defineProps({
       </div>
     </div>
 
+    <!-- Half Championship -->
+    <div class="bg-white rounded-lg shadow-md p-4 text-center border-t-4 border-amber-300">
+      <div class="text-3xl font-bold text-amber-500">{{ stats.halfChampionships.count }}</div>
+      <div class="text-sm text-gray-500 mt-1">Half a Championship</div>
+      <div class="text-xs text-gray-400">
+        {{ stats.halfChampionships.teams.join(', ') }}
+      </div>
+    </div>
+
+    <!-- Back to Back -->
+    <div class="bg-white rounded-lg shadow-md p-4 text-center border-t-4 border-green-500">
+      <div class="text-3xl font-bold text-green-600">{{ stats.backToBack.count }}</div>
+      <div class="text-sm text-gray-500 mt-1">Back to Back Champs</div>
+      <div class="text-xs text-gray-400">
+        {{ stats.backToBack.teams.join(', ') }}
+      </div>
+    </div>
+
     <!-- Years Since Title -->
     <div class="bg-white rounded-lg shadow-md p-4 text-center border-t-4 border-red-500">
       <template v-if="stats.longestDrought">
         <div class="text-3xl font-bold text-red-600">{{ stats.longestDrought.years }}</div>
-        <div class="text-sm text-gray-500 mt-1">Years Since Title</div>
+        <div class="text-sm text-gray-500 mt-1">Most Years Since Title</div>
         <div class="text-xs text-gray-400">{{ stats.longestDrought.team }}</div>
       </template>
       <template v-else>
         <div class="text-3xl font-bold text-gray-600">--</div>
         <div class="text-sm text-gray-500 mt-1">Longest Drought</div>
       </template>
-    </div>
-
-    <!-- Unique Champions -->
-    <div class="bg-white rounded-lg shadow-md p-4 text-center border-t-4 border-amber-500">
-      <div class="text-3xl font-bold text-amber-600">{{ stats.uniqueChampions }}</div>
-      <div class="text-sm text-gray-500 mt-1">Unique Champions</div>
     </div>
 
     <!-- Most Titles -->

--- a/src/components/champions/YearsSinceLastTitle.vue
+++ b/src/components/champions/YearsSinceLastTitle.vue
@@ -1,0 +1,103 @@
+<script setup>
+const props = defineProps({
+  data: {
+    type: Array,
+    required: true
+  }
+})
+
+// Import all logo images dynamically
+const logoModules = import.meta.glob('@/assets/*.{jpg,png}', { eager: true })
+
+const getLogoUrl = (teamName) => {
+  // Map team names to logo filenames
+  const logoMap = {
+    'AMW': 'amw.jpg',
+    'Blank': 'blank.jpg',
+    'Birrrdy': 'birrrdy.jpg',
+    'Burghman': 'burghman.jpg',
+    'Gunslingers': 'gunslingers.jpg',
+    'Hampton Ballers': 'hb.jpg',
+    "Jamaica's Finest": 'jf.jpg',
+    'Junkyard Dawgs': 'jyd.jpg',
+    'Makaveli': 'mak.jpg',
+    'Menace': 'menace.jpg',
+    'Outta Control': 'oc.jpg',
+    'Showtime': 'showtime.jpg',
+    'Skindeep Ballaz': 'skindeep.png',
+    'Stout': 'stout.jpg'
+  }
+
+  const logoFile = logoMap[teamName]
+  if (!logoFile) return null
+
+  for (const [key, module] of Object.entries(logoModules)) {
+    if (key.endsWith(logoFile)) {
+      return module.default
+    }
+  }
+  return null
+}
+
+const formatYears = (team) => {
+  if (!team.hasWon) {
+    const times = team.appearances === 1 ? 'time' : 'times'
+    return `Never won, but they have appeared in the title game ${team.appearances} ${times}`
+  }
+  if (team.yearsSince === 0) {
+    return 'Current champion'
+  }
+  if (team.yearsSince === 1) {
+    return '1 year'
+  }
+  return `${team.yearsSince} years`
+}
+</script>
+
+<template>
+  <div class="mt-8">
+    <h2 class="text-xl font-bold mb-4 text-gray-800">Years Since Last Title</h2>
+
+    <div class="bg-white rounded-lg shadow-lg overflow-hidden">
+      <table class="w-full">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Team</th>
+            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Years Since Title</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+          <tr
+            v-for="team in data"
+            :key="team.name"
+            class="hover:bg-gray-50"
+          >
+            <td class="px-6 py-4 whitespace-nowrap">
+              <div class="flex items-center">
+                <img
+                  v-if="getLogoUrl(team.name)"
+                  :src="getLogoUrl(team.name)"
+                  :alt="team.name"
+                  class="w-8 h-8 rounded-full border-2 border-gray-200 mr-3"
+                />
+                <div v-else class="w-8 h-8 rounded-full bg-gray-200 mr-3"></div>
+                <span class="text-sm font-medium text-gray-900">{{ team.name }}</span>
+              </div>
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-right">
+              <span
+                :class="{
+                  'text-amber-600 font-semibold': team.yearsSince === 0,
+                  'text-gray-600': team.hasWon && team.yearsSince > 0,
+                  'text-gray-400 italic': !team.hasWon
+                }"
+              >
+                {{ formatYears(team) }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/src/pages/ChampionsPage.vue
+++ b/src/pages/ChampionsPage.vue
@@ -3,8 +3,9 @@ import { useChampionshipData } from '../composables/useChampionshipData'
 import ChampionshipStats from '../components/champions/ChampionshipStats.vue'
 import ChampionshipHistory from '../components/champions/ChampionshipHistory.vue'
 import ChampionshipSummary from '../components/champions/ChampionshipSummary.vue'
+import YearsSinceLastTitle from '../components/champions/YearsSinceLastTitle.vue'
 
-const { seasons, loading, error, stats, championshipTiers } = useChampionshipData()
+const { seasons, loading, error, stats, championshipTiers, yearsSinceLastTitle } = useChampionshipData()
 </script>
 
 <template>
@@ -24,6 +25,9 @@ const { seasons, loading, error, stats, championshipTiers } = useChampionshipDat
 
         <!-- Championship Summary by Tier -->
         <ChampionshipSummary :tiers="championshipTiers" />
+
+        <!-- Years Since Last Title -->
+        <YearsSinceLastTitle :data="yearsSinceLastTitle" />
       </template>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Add **Years Since Last Title** table to Champions page showing team logos, names, and years since last championship
- Fix championship year offset calculation (championship crowned in draft year + 1)
- Add **Half a Championship** stat card for co-champions
- Add **Back to Back Champs** stat card for consecutive year winners
- Remove Unique Champions card
- Enhanced "Never won" display with title game appearance count, sorted by most appearances

## Test plan
- [ ] Navigate to Champions page
- [ ] Verify stat cards display correctly (Total Seasons, No Titles, Half a Championship, Back to Back Champs, Most Years Since Title, Most Titles)
- [ ] Verify "Years Since Last Title" table appears after Championships (Appearances) section
- [ ] Verify current champion shows "Current champion" (0 years)
- [ ] Verify "Never won" teams show appearance count and are sorted by most appearances
- [ ] Verify Most Years Since Title card matches first entry in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)