### PR TITLE
Fix SPA routing for page refresh on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,6 @@
 {
-  "framework": "vite"
+  "framework": "vite",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add rewrite rule to `vercel.json` to handle client-side routing
- Fixes 404 errors when refreshing the page on routes like `/teams`, `/drafts`, etc.

## Problem
Without this rewrite, Vercel looks for a file at the requested path (e.g., `/teams`) instead of serving `index.html` and letting Vue Router handle the routing client-side.

## Test plan
- [ ] Deploy to Vercel
- [ ] Navigate to Teams page
- [ ] Refresh the page - should load correctly instead of showing 404
- [ ] Test direct URL access to `/teams`, `/drafts`, `/champions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)