### PR TITLE
Fix responsive table and vercel dev compatibility

### DIFF
--- a/src/components/champions/YearsSinceLastTitle.vue
+++ b/src/components/champions/YearsSinceLastTitle.vue
@@ -58,12 +58,12 @@ const formatYears = (team) => {
   <div class="mt-8">
     <h2 class="text-xl font-bold mb-4 text-gray-800">Years Since Last Title</h2>
 
-    <div class="bg-white rounded-lg shadow-lg overflow-hidden">
-      <table class="w-full">
+    <div class="bg-white rounded-lg shadow-lg overflow-x-auto">
+      <table class="w-full min-w-0">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Team</th>
-            <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Years Since Title</th>
+            <th class="px-3 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Team</th>
+            <th class="px-3 sm:px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Years Since Title</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
@@ -72,20 +72,21 @@ const formatYears = (team) => {
             :key="team.name"
             class="hover:bg-gray-50"
           >
-            <td class="px-6 py-4 whitespace-nowrap">
+            <td class="px-3 sm:px-6 py-3 sm:py-4 whitespace-nowrap">
               <div class="flex items-center">
                 <img
                   v-if="getLogoUrl(team.name)"
                   :src="getLogoUrl(team.name)"
                   :alt="team.name"
-                  class="w-8 h-8 rounded-full border-2 border-gray-200 mr-3"
+                  class="w-6 h-6 sm:w-8 sm:h-8 rounded-full border-2 border-gray-200 mr-2 sm:mr-3 flex-shrink-0"
                 />
-                <div v-else class="w-8 h-8 rounded-full bg-gray-200 mr-3"></div>
-                <span class="text-sm font-medium text-gray-900">{{ team.name }}</span>
+                <div v-else class="w-6 h-6 sm:w-8 sm:h-8 rounded-full bg-gray-200 mr-2 sm:mr-3 flex-shrink-0"></div>
+                <span class="text-xs sm:text-sm font-medium text-gray-900">{{ team.name }}</span>
               </div>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-right">
+            <td class="px-3 sm:px-6 py-3 sm:py-4 text-right">
               <span
+                class="text-xs sm:text-sm"
                 :class="{
                   'text-amber-600 font-semibold': team.yearsSince === 0,
                   'text-gray-600': team.hasWon && team.yearsSince > 0,

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,3 @@
 {
-  "framework": "vite",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
-  ]
+  "framework": "vite"
 }


### PR DESCRIPTION
## Summary
- Make **Years Since Last Title** table responsive for mobile screens
- Fix `vercel dev` asset loading by removing problematic rewrite rule

## Changes
- Reduce padding on mobile (px-3 sm:px-6)
- Smaller logos on mobile (w-6 h-6 sm:w-8 sm:h-8)  
- Smaller text on mobile (text-xs sm:text-sm)
- Add overflow-x-auto for horizontal scroll fallback
- Remove rewrite rule from vercel.json that was breaking asset loading in `vercel dev`

## Test plan
- [ ] Run `vercel dev` - assets should load correctly
- [ ] View Champions page on mobile - Years Since Last Title table should be readable
- [ ] Deploy and test page refresh on routes like `/teams` in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)