### PR TITLE
Fix SPA routing with 404.html redirect

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <script>
+      // Single Page App redirect for Vercel
+      // Preserves the path and query string when redirecting to index.html
+      const path = window.location.pathname + window.location.search + window.location.hash;
+      sessionStorage.setItem('spa-redirect', path);
+      window.location.replace('/');
+    </script>
+  </head>
+  <body>
+    <p>Redirecting...</p>
+  </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -6,3 +6,10 @@ import './assets/main.css'
 const app = createApp(App)
 app.use(router)
 app.mount('#app')
+
+// Handle SPA redirect from 404.html
+const redirectPath = sessionStorage.getItem('spa-redirect')
+if (redirectPath) {
+  sessionStorage.removeItem('spa-redirect')
+  router.replace(redirectPath)
+}


### PR DESCRIPTION
## Summary
Fix the 404 error when refreshing on routes like `/drafts` or `/teams` in production.

## Approach
Uses a 404.html redirect pattern that works with both `vercel dev` and production:

1. When Vercel can't find a route (e.g., `/drafts`), it serves `404.html`
2. `404.html` saves the original path to sessionStorage and redirects to `/`
3. The app loads at `/` and checks sessionStorage for a saved path
4. If found, it navigates to that path using Vue Router

## Test plan
- [x] `vercel dev` works locally
- [ ] Deploy and test page refresh on `/drafts` in production
- [ ] Test page refresh on `/teams`, `/champions`
- [ ] Test direct URL access to routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)